### PR TITLE
Constructors with String Vectors

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -86,8 +86,7 @@ function DataFrame(columns::Vector{Any},
 end
 
 # Pandas' Dict of Vectors -> DataFrame constructor w/ explicit column names
-import Base.convert
-convert(::Type{DataFrame}, d::Dict) = begin
+function Base.convert(::Type{DataFrame}, d::Dict)
     d = convert(Dict{Symbol, eltype(d)[2]}, d)
     cnames = sort([x for x in keys(d)])
     p = length(cnames)
@@ -102,7 +101,7 @@ convert(::Type{DataFrame}, d::Dict) = begin
         end
         columns[j] = DataArray(d[cnames[j]])
     end
-    DataFrame(columns, Index(cnames))
+    return DataFrame(columns, Index(cnames))
 end
 
 # Pandas' Dict of Vectors -> DataFrame constructor w/o explicit column names

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -86,7 +86,8 @@ function DataFrame(columns::Vector{Any},
 end
 
 # Pandas' Dict of Vectors -> DataFrame constructor w/ explicit column names
-function DataFrame(d::Dict)
+import Base.convert
+convert(::Type{DataFrame}, d::Dict) = begin
     d = convert(Dict{Symbol, eltype(d)[2]}, d)
     cnames = sort([x for x in keys(d)])
     p = length(cnames)
@@ -101,7 +102,7 @@ function DataFrame(d::Dict)
         end
         columns[j] = DataArray(d[cnames[j]])
     end
-    return DataFrame(columns, Index(cnames))
+    DataFrame(columns, Index(cnames))
 end
 
 # Pandas' Dict of Vectors -> DataFrame constructor w/o explicit column names

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -106,6 +106,8 @@ end
 
 # Pandas' Dict of Vectors -> DataFrame constructor w/o explicit column names
 function DataFrame(d::Dict, cnames::Vector)
+    d = convert(Dict{Symbol, eltype(d)[2]}, d)
+    cnames = convert(Vector{Symbol}, cnames)
     p = length(cnames)
     if p == 0
         DataFrame()

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -87,7 +87,7 @@ end
 
 # Pandas' Dict of Vectors -> DataFrame constructor w/ explicit column names
 function DataFrame(d::Dict)
-    d = convert(Dict{Symbol, Any}, d)
+    d = convert(Dict{Symbol, eltype(d)[2]}, d)
     cnames = sort([x for x in keys(d)])
     p = length(cnames)
     if p == 0

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -87,7 +87,8 @@ end
 
 # Pandas' Dict of Vectors -> DataFrame constructor w/ explicit column names
 function DataFrame(d::Dict)
-    cnames = sort(Symbol[x for x in keys(d)])
+    d = convert(Dict{Symbol, Any}, d)
+    cnames = sort([x for x in keys(d)])
     p = length(cnames)
     if p == 0
         return DataFrame()

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -61,6 +61,12 @@ function DataFrame(x::Matrix, cn::Vector = gennames(size(x, 2)))
     return DataFrame(cols, Index(cn))
 end
 
+function DataFrame(d::Dict)
+    depwarn("DataFrame(::Dict) is deprecated, use convert(DataFrame, Dict) instead",
+            :DataFrame)
+    convert(DataFrame, d)
+end
+
 function DataFrame{T<:String}(columns::Vector{Any}, cnames::Vector{T})
     depwarn("DataFrame(::Vector{Any}, ::Vector{T<:String}) is deprecated, use DataFrame(::Vector{Any}, ::Vector{Symbol}) instead",
             :DataFrame)

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -20,6 +20,18 @@ function Index(x::Vector{Symbol})
     x = make_unique(x)
     Index(Dict{Symbol, Indices}(tuple(x...), tuple([1:length(x)]...)), x)
 end
+function Index(x::Vector)
+    try
+        x = convert(Vector{Symbol}, x)
+    catch error
+        if isa(error, MethodError)
+            error("Names must be able to convert to symbols.")
+        else
+            throw(error)
+        end
+    end
+    Index(x)
+end
 Index() = Index(Dict{Symbol, Indices}(), Symbol[])
 Base.length(x::Index) = length(x.names)
 Base.names(x::Index) = copy(x.names)

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -47,4 +47,8 @@ module TestConstructors
     @test all(eltypes(df) .== {Int, Float64})
 
     @test isequal(df, DataFrame([Int, Float64], 2))
+
+    df1 = DataFrame({"a" => [1 2], "b" => [3 4]})
+    df2 = DataFrame({:a => [1 2], :b => [3 4]})
+    @test isequal(df1, df2)
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -47,12 +47,4 @@ module TestConstructors
     @test all(eltypes(df) .== {Int, Float64})
 
     @test isequal(df, DataFrame([Int, Float64], 2))
-
-    df1 = DataFrame({"a" => [1 2], "b" => [3 4]})
-    df2 = DataFrame({:a => [1 2], :b => [3 4]})
-    df3 = DataFrame({"a" => [1 2], "b" => [3 4]}, ["a", "b"])
-    df4 = DataFrame({:a => [1 2], :b => [3 4]}, ["a", "b"])
-    @test isequal(df1, df2)
-    @test isequal(df1, df3)
-    @test isequal(df1, df4)
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -50,5 +50,9 @@ module TestConstructors
 
     df1 = DataFrame({"a" => [1 2], "b" => [3 4]})
     df2 = DataFrame({:a => [1 2], :b => [3 4]})
+    df3 = DataFrame({"a" => [1 2], "b" => [3 4]}, ["a", "b"])
+    df4 = DataFrame({:a => [1 2], :b => [3 4]}, ["a", "b"])
     @test isequal(df1, df2)
+    @test isequal(df1, df3)
+    @test isequal(df1, df4)
 end

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -21,4 +21,12 @@ module TestConversions
     @test isa(array(df), Matrix{Float64})
     # @test isa(matrix(df, Any), Matrix{Any})
     # @test isa(matrix(df, Int), Matrix{Int})
+
+    df1 = convert(DataFrame, {"a" => [1 2], "b" => [3 4]})
+    df2 = convert(DataFrame, {:a => [1 2], :b => [3 4]})
+    df3 = convert(DataFrame, {"a" => [1 2], "b" => [3 4]}, ["a", "b"])
+    df4 = convert(DataFrame, {:a => [1 2], :b => [3 4]}, ["a", "b"])
+    @test isequal(df1, df2)
+    @test isequal(df1, df3)
+    @test isequal(df1, df4)
 end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -117,7 +117,7 @@ module TestDataFrame
     @test typeof(df[:,:b]) == DataVector{Char}
 
     data = {:A => [1, 2], :C => [:1, :2], :B => [3, 4]}
-    df = DataFrame(data)
+    df = convert(DataFrame, data)
     # Specify column_names
     df = DataFrame(data, [:C, :A, :B])
 

--- a/test/index.jl
+++ b/test/index.jl
@@ -50,4 +50,6 @@ Index(Symbol["a"])
 @test_throws ErrorException Index(Symbol["end"])
 @test_throws ErrorException Index(Symbol["1a"])
 
+@test Index(["a"]) == Index([:a])
+
 end


### PR DESCRIPTION
fixes #625 (and basically similar to #626)
fixes #289

Allows constructors for Index and DataFrame to using Vectors of strings rather than symbols.

The last commit, depreciates DataFrame(Dict) in favor of convert.