### PR TITLE
convert 2dim DataArray to multi-column DataFrame

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -794,6 +794,18 @@ function Base.append!(df1::DataFrame, df2::AbstractDataFrame)
    return df1
 end
 
+function Base.convert(::Type{DataFrame}, A::DataArray)
+    if length(size(A)) > 2
+        error("Not implemented DataFrame with dimension > 2")
+    end
+    n = size(A, 1)
+    cols = Array(Any, n)
+    for i in 1:n
+        cols[i] = A[i, :]
+    end
+    return DataFrame(cols, Index(gennames(n)))
+end
+
 function Base.convert(::Type{DataFrame}, A::Matrix)
     n = size(A, 2)
     cols = Array(Any, n)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -794,19 +794,7 @@ function Base.append!(df1::DataFrame, df2::AbstractDataFrame)
    return df1
 end
 
-function Base.convert(::Type{DataFrame}, A::DataArray)
-    if length(size(A)) > 2
-        error("Not implemented DataFrame with dimension > 2")
-    end
-    n = size(A, 1)
-    cols = Array(Any, n)
-    for i in 1:n
-        cols[i] = A[i, :]
-    end
-    return DataFrame(cols, Index(gennames(n)))
-end
-
-function Base.convert(::Type{DataFrame}, A::Matrix)
+function Base.convert(::Type{DataFrame}, A::AbstractMatrix)
     n = size(A, 2)
     cols = Array(Any, n)
     for i in 1:n

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -19,7 +19,7 @@ module TestConversions
 
     da1 = @data([1 NA 3 4 5 6])
     df = convert(DataFrame, da1)
-    @test size(df) == (6, 1)
+    @test size(df) == (1, 6)
 
     da2 = @data([1 NA; 3 4; 5 6])
     df = convert(DataFrame, da2)

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -17,6 +17,14 @@ module TestConversions
     @test isa(convert(Array{Any}, df), Matrix{Any})
     @test isa(convert(Array{Float64}, df), Matrix{Float64})
 
+    da1 = @data([1 NA 3 4 5 6])
+    df = convert(DataFrame, da1)
+    @test size(df) == (6, 1)
+
+    da2 = @data([1 NA; 3 4; 5 6])
+    df = convert(DataFrame, da2)
+    @test size(df) == (3, 2)
+
     df = DataFrame()
     df[:A] = 1.0:5.0
     df[:B] = 1.0:5.0


### PR DESCRIPTION
Previously:

```
julia> @data([1 NA; 3 4; 5 6])
3x2 DataArray{Int64,2}:
 1   NA
 3  4  
 5  6  

julia> convert(DataFrame, ans)
6x1 DataFrame
|-------|----|
| Row # | x1 |
| 1     | 1  |
| 2     | NA |
| 3     | 3  |
| 4     | 4  |
| 5     | 5  |
| 6     | 6  |
```

I think it's expected that these should be converted to multiple columns:

```
julia> convert(DataFrame, ans)
2x3 DataFrame
|-------|----|----|----|
| Row # | x1 | x2 | x3 |
| 1     | 1  | 3  | 5  |
| 2     | NA | 4  | 6  |
```
