### PR TITLE
[WIP] Use convert instead of array

### DIFF
--- a/doc/sections/02_getting_started.md
+++ b/doc/sections/02_getting_started.md
@@ -51,11 +51,11 @@ no `NA` values:
     convert(Array, dv)
 
 In addition to removing `NA` values and hoping they won't occur, you can
-also replace any `NA` values using the `array` function, which takes a
+also replace any `NA` values using the `convert` function, which takes a
 replacement value as an argument:
 
     dv = @data([NA, 3, 2, 5, 4])
-    mean(array(dv, 11))
+    mean(convert(Vector, dv, 11))
 
 Which strategy for dealing with `NA` values is most appropriate will
 typically depend on the specific details of your data analysis pathway.
@@ -92,7 +92,7 @@ We can also look at small subsets of the data in a couple of different ways:
 
     head(df)
     tail(df)
-    
+
     df[1:3, :]
 
 Having seen what some of the rows look like, we can try to summarize the

--- a/sphinxdoc/source/getting_started.rst
+++ b/sphinxdoc/source/getting_started.rst
@@ -54,11 +54,11 @@ no ``NA`` values::
     convert(Array, dv)
 
 In addition to removing ``NA`` values and hoping they won't occur, you can
-also replace any ``NA`` values using the ``array`` function, which takes a
+also replace any ``NA`` values using the ``convert`` function, which takes a
 replacement value as an argument::
 
     dv = @data([NA, 3, 2, 5, 4])
-    mean(array(dv, 11))
+    mean(convert(Vector, dv, 11))
 
 Which strategy for dealing with ``NA`` values is most appropriate will
 typically depend on the specific details of your data analysis pathway.

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -34,4 +34,40 @@ Base.next(r::DataFrameRow, s) = ((names(r)[s], r[s]), s + 1)
 
 Base.done(r::DataFrameRow, s) = s > length(r)
 
-DataArrays.array(r::DataFrameRow) = DataArrays.array(r.df[r.row,:])
+function DataArrays.array(r::DataFrameRow)
+    Base.depwarn(
+        """
+        array(r::DataFrameRow) is deprecated.
+        Use convert(Matrix, r).
+        """,
+        :array
+    )
+    return DataArrays.array(r.df[r.row,:])
+end
+
+function Base.convert{T}(::Type{Matrix{T}}, r::DataFrameRow)
+    return convert(Matrix{T}, r.df[r.row, :])
+end
+
+function Base.convert(::Type{Matrix}, r::DataFrameRow)
+    return convert(Matrix{typejoin(eltypes(r.df)...)}, r.df[r.row, :])
+end
+
+function Base.convert{T}(::Type{Vector{T}}, r::DataFrameRow)
+    ncols = size(r.df, 2)
+    res = Array(T, ncols)
+    for j in 1:ncols
+        res[j] = convert(T, r.df[r.row, j])
+    end
+    return res
+end
+
+function Base.convert(::Type{Vector}, r::DataFrameRow)
+    return convert(Vector{typejoin(eltypes(r.df)...)}, r)
+end
+
+# TODO:
+# Convert to DataVector{T}, DataVector, DataMatrix{T}, DataMatrix
+
+# Should this allow NA's?
+# Base.convert(Dict, r::DataFrameRow) = Vector{Any}...

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -104,7 +104,7 @@ end
 
 Base.getindex(x::Index, idx::Symbol) = x.lookup[idx]
 Base.getindex(x::AbstractIndex, idx::Real) = int(idx)
-Base.getindex(x::AbstractIndex, idx::AbstractDataVector{Bool}) = getindex(x, array(idx, false))
+Base.getindex(x::AbstractIndex, idx::AbstractDataVector{Bool}) = getindex(x, convert(Vector, idx, false))
 Base.getindex{T}(x::AbstractIndex, idx::AbstractDataVector{T}) = getindex(x, dropna(idx))
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Bool}) = find(idx)
 Base.getindex(x::AbstractIndex, idx::Ranges) = [idx]

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -5,20 +5,19 @@ module TestConversions
     df = DataFrame()
     df[:A] = 1:5
     df[:B] = [:A, :B, :C, :D, :E]
-    @test isa(array(df), Matrix{Any})
-    # @test isa(array(df, Any), Matrix{Any})
+    @test isa(convert(Matrix, df), Matrix{Any})
+    @test isa(convert(Matrix{Any}, df), Matrix{Any})
 
     df = DataFrame()
     df[:A] = 1:5
     df[:B] = 1.0:5.0
-    @test isa(array(df), Matrix{Real})
-    # @test isa(array(df, Any), Matrix{Any})
-    # @test isa(array(df, Float64), Matrix{Float64})
+    @test isa(convert(Matrix, df), Matrix{Real})
+    @test isa(convert(Matrix{Float64}, df), Matrix{Float64})
 
     df = DataFrame()
     df[:A] = 1.0:5.0
     df[:B] = 1.0:5.0
-    @test isa(array(df), Matrix{Float64})
-    # @test isa(matrix(df, Any), Matrix{Any})
-    # @test isa(matrix(df, Int), Matrix{Int})
+    @test isa(convert(Matrix, df), Matrix{Float64})
+    @test isa(convert(Matrix{Float64}, df), Matrix{Float64})
+    @test isa(convert(Matrix{Int}, df), Matrix{Int})
 end

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -29,7 +29,7 @@ module TestIteration
         @test isa(col, (Symbol, AbstractDataVector))
     end
 
-    @test isequal(map(x -> minimum(array(x)), eachrow(df)), {1,2})
+    @test isequal(map(row -> minimum(convert(Matrix, row)), eachrow(df)), {1,2})
     @test isequal(map(minimum, eachcol(df)), DataFrame(A = [1], B = [2]))
 
     row = DataFrameRow(df, 1)


### PR DESCRIPTION
This begins the process of standardizing on the use of `convert` instead of `array`. Right now, this is focused on converting DataFrame and DataFrameRow objects to other types. Before I'm finished, I'd also like to deprecate the constructors that take in other types and convert those types to DataFrames.

EDIT: This PR depends upon a PR for DataArrays.jl that makes similar changes.
