### PR TITLE
Add ablity to sample a dataframe

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -680,7 +680,7 @@ end
 
 ##############################################################################
 ##
-## head() and tail()
+## head(), tail() and sample()
 ##
 ##############################################################################
 
@@ -688,6 +688,14 @@ DataArrays.head(df::AbstractDataFrame, r::Int) = df[1:min(r,nrow(df)), :]
 DataArrays.head(df::AbstractDataFrame) = head(df, 6)
 DataArrays.tail(df::AbstractDataFrame, r::Int) = df[max(1,nrow(df)-r+1):nrow(df), :]
 DataArrays.tail(df::AbstractDataFrame) = tail(df, 6)
+
+function StatsBase.sample(df::AbstractDataFrame, n::Integer)
+    if n >= nrow(df)
+        return df
+    else
+        return df[sort(sample(1:nrow(df), n, replace=false)), :]
+    end
+end
 
 # get the structure of a DF
 function Base.dump(io::IO, x::AbstractDataFrame, n::Int, indent)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -251,4 +251,23 @@ module TestDataFrame
     df = DataFrame(a=@data([1, 2, 3]), b=@data([3., 4., 5.]))
     @test deleterows!(df, [2, 3]) === df
     @test isequal(df, DataFrame(a=@data([1]), b=@data([3.])))
+
+    #head, tail and sample
+    data = rand(1:20, 10, 3)
+    df = convert(DataFrame,data)
+
+    @test head(df) == convert(DataFrame, data[1:6, :])
+    @test head(df, 5) == convert(DataFrame, data[1:5, :])
+    @test head(df, 20) == df
+
+    @test tail(df) == convert(DataFrame, data[5:end, :])
+    @test tail(df, 5) == convert(DataFrame, data[6:end, :])
+    @test tail(df, 20) == df
+
+    srand(42)
+    df1 = sample(df, 5)
+    srand(42)
+    @test df1 == convert(DataFrame,
+                         data[sort(sample(1:10, 5, replace=false)), :])
+    @test sample(df, 15) == df
 end


### PR DESCRIPTION
If you have a ordered or sorted DataFrame then just looking at the head or tail may give you a very unrepresentative view of the data. This PR extends `sample` to sample rows from a DataFrame. 

While adding tests for `sample()` I also added a few tests for `head()` and `tail()`.

One thing I want to ask is what the policy is for type annotations for function arguments. I've annotated `n` to `Integer` which is what it is annotated with in StatsBase. Would it be better to leave it as something more generic and just delegate the method error to the StatsBase sample method?

One shortcoming of the current implmentation is that the DataFrame resulting from the sampling doesn't save the row numbers of the original DataFrame so you don't know which rows you are looking at. `tail()` has the same shortcoming, although in that case figuring out the row numbers yourself is easier. 
