### PR TITLE
append! should not take the order of columns into account.

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -693,12 +693,12 @@ function pool!(df::DataFrame)
 end
 
 function Base.append!(df1::DataFrame, df2::AbstractDataFrame)
-   names(df1) == names(df2) || error("Column names do not match")
-   eltypes(df1) == eltypes(df2) || error("Column eltypes do not match")
-   ncols = size(df1, 2)
+   df1_names = sort(names(df1))
+   df1_names == sort(names(df2)) || error("Column names do not match")
+   eltypes(df1[df1_names]) == eltypes(df2[df1_names]) || error("Column eltypes do not match")
    # TODO: This needs to be a sort of transaction to be 100% safe
-   for j in 1:ncols
-       append!(df1[j], df2[j])
+   for c in df1_names
+       append!(df1[c], df2[c])
    end
    return df1
 end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -270,4 +270,13 @@ module TestDataFrame
     df = DataFrame(a=@data([1, 2, 3]), b=@data([3., 4., 5.]))
     @test deleterows!(df, [2, 3]) === df
     @test isequal(df, DataFrame(a=@data([1]), b=@data([3.])))
+
+    # Test append!
+    df1 = DataFrame(a=@data([1, 2, 3]), b=@data([3., 4., 5.]))
+    df2 = DataFrame(b=@data([6., 7., 8.]), a=@data([4, 5, 6]))
+    df3 = DataFrame(a=@data([1, 2, 3, 4, 5, 6]), b= @data([3., 4., 5., 6., 7., 8.]))
+
+    append!(df1, df2)
+
+    @test df1 == df3
 end


### PR DESCRIPTION
I had code ~~that worked before 891f713￼~~ that depended on `append!` ignoring the order of columns in the DataFrame. After looking at the code I don't know why it ever *was supposed* to work ~~ed~~, but I figured removing the dependence on the order of the columns would be an improvement.