### PR TITLE
Optimize RDAIO

### DIFF
--- a/src/RDA.jl
+++ b/src/RDA.jl
@@ -133,14 +133,15 @@ sxtype = uint8
 ##############################################################################
 
 # abstract RDA format IO stream wrapper
-abstract RDAIO 
+abstract RDAIO
 
-type RDAXDRIO <: RDAIO # RDA XDR(binary) format IO stream wrapper
-    sub::IO            # underlying IO stream
+type RDAXDRIO{T<:IO} <: RDAIO # RDA XDR(binary) format IO stream wrapper
+    sub::T             # underlying IO stream
     buf::Vector{Uint8} # buffer for strings
 
-    RDAXDRIO( io::IO ) = new( io, Array(Uint8, 1024) )
+    RDAXDRIO( io::T ) = new( io, Array(Uint8, 1024) )
 end
+RDAXDRIO{T <: IO}(io::T) = RDAXDRIO{T}(io)
 
 readint32(io::RDAXDRIO) = ntoh(read(io.sub, Int32))
 readuint32(io::RDAXDRIO) = ntoh(read(io.sub, Uint32))
@@ -157,11 +158,12 @@ function readnchars(io::RDAXDRIO, n::Int32)  # a single character string
     bytestring(pointer(io.buf), n)::ASCIIString
 end
 
-type RDAASCIIIO <: RDAIO # RDA ASCII format IO stream wrapper
-    sub::IO              # underlying IO stream
+type RDAASCIIIO{T<:IO} <: RDAIO # RDA ASCII format IO stream wrapper
+    sub::T              # underlying IO stream
 
-    RDAASCIIIO( io::IO ) = new( io )
+    RDAASCIIIO( io::T ) = new( io )
 end
+RDAASCIIIO{T <: IO}(io::T) = RDAASCIIIO{T}(io)
 
 readint32(io::RDAASCIIIO) = int32(readline(io.sub))
 readuint32(io::RDAASCIIIO) = uint32(readline(io.sub))
@@ -186,11 +188,12 @@ function readnchars(io::RDAASCIIIO, n::Int32)  # reads N bytes-sized string
     str
 end
 
-type RDANativeIO <: RDAIO # RDA native binary format IO stream wrapper (TODO)
-    sub::IO               # underlying IO stream
+type RDANativeIO{T<:IO} <: RDAIO # RDA native binary format IO stream wrapper (TODO)
+    sub::T               # underlying IO stream
 
-    RDANativeIO( io::IO ) = new( io )
+    RDANativeIO( io::T ) = new( io )
 end
+RDANativeIO{T <: IO}(io::T) = RDANativeIO{T}(io)
 
 function rdaio(io::IO, formatcode::AbstractString)
     if formatcode == "X" RDAXDRIO(io)

--- a/src/RDA.jl
+++ b/src/RDA.jl
@@ -142,19 +142,19 @@ type RDAXDRIO <: RDAIO # RDA XDR(binary) format IO stream wrapper
     RDAXDRIO( io::IO ) = new( io, Array(Uint8, 1024) )
 end
 
-readint32(io::RDAXDRIO) = hton(read(io.sub, Int32))
-readuint32(io::RDAXDRIO) = hton(read(io.sub, Uint32))
-readfloat64(io::RDAIO) = hton(read(io.sub, Float64))
+readint32(io::RDAXDRIO) = ntoh(read(io.sub, Int32))
+readuint32(io::RDAXDRIO) = ntoh(read(io.sub, Uint32))
+readfloat64(io::RDAXDRIO) = ntoh(read(io.sub, Float64))
 
 readintorNA(io::RDAXDRIO) = readint32(io)
-readintorNA(io::RDAXDRIO, n::Int64) = map!(hton, read(io.sub, Int32, n))
+readintorNA(io::RDAXDRIO, n::Int64) = map!(ntoh, read(io.sub, Int32, n))
 
 readfloatorNA(io::RDAXDRIO) = readfloat64(io)
-readfloatorNA(io::RDAXDRIO, n::Int64) = map!(hton, read(io.sub, Float64, n))
+readfloatorNA(io::RDAXDRIO, n::Int64) = map!(ntoh, read(io.sub, Float64, n))
 
 function readnchars(io::RDAXDRIO, n::Int32)  # a single character string
     readbytes!(io.sub, io.buf, n)
-    bytestring(pointer(io.buf), n)
+    bytestring(pointer(io.buf), n)::ASCIIString
 end
 
 type RDAASCIIIO <: RDAIO # RDA ASCII format IO stream wrapper
@@ -182,7 +182,8 @@ readfloatorNA(io::RDAASCIIIO, n::Int64) = Float64[readfloatorNA(io) for i in 1:n
 function readnchars(io::RDAASCIIIO, n::Int32)  # reads N bytes-sized string
     if (n==-1) return "" end
     str = unescape_string(chomp(readline(io.sub)))
-    return length(str) == n ? str : error("Character string length mismatch")
+    length(str) == n || error("Character string length mismatch")
+    str
 end
 
 type RDANativeIO <: RDAIO # RDA native binary format IO stream wrapper (TODO)

--- a/test/RDA.jl
+++ b/test/RDA.jl
@@ -47,8 +47,10 @@ module TestRDA
     df[3, :num] = NaN
     df[:, :cplx] = @data [NA, complex128(1,NaN), NaN]
     @test isequal(DataFrame(read_rda("$testdir/data/RDA/NAs.rda")["df"]), df)
-    # NA ASCII test disabled for now, because NaN are saved as NA. Investigating it from R side.
-    #@test isequal(DataFrame(read_rda("$testdir/data/RDA/NAs_ascii.rda")["df"]), df)
+    # ASCII format saves NaN as NA
+    df[3, :num] = NA
+    df[:, :cplx] = @data [NA, NA, NA]
+    @test isequal(DataFrame(read_rda("$testdir/data/RDA/NAs_ascii.rda")["df"]), df)
 
     rda_names = names(DataFrame(read_rda("$testdir/data/RDA/names.rda")["df"]))
     expected_names = [:_end, :x!, :x1, :_B_C_, :x, :x_1]


### PR DESCRIPTION
Another round of RDA performance polishing:
1. Make long R vectors support optional. Disable by default on 32-bit systems (it's unlikely many people work with big dataframes on 32-bit systems, and in all other cases iterating over Int64 variable just slows everything down), R does the same.
2. Get >20% improvement in time and memory by improving type inference of IO variable. Before:
```bash
[~]$ julia -e "using DataFrames; @time read_rda(\"test.RData\")"
elapsed time: 15.414509979 seconds (2433718088 bytes allocated, 5.44% gc time)
```
after
```bash
[~]$ julia -e "using DataFrames; @time read_rda(\"test.RData\")"
elapsed time: 12.278712969 seconds (1834821860 bytes allocated, 3.38% gc time)
```