### PR TITLE
Fix writetable test for Windows, writetable bug

### DIFF
--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -71,7 +71,11 @@ function writetable(filename::String,
                     quotemark::Char = '"',
                     append::Bool = false)
 
-    if append && isfile(filename)
+    if endswith(filename, ".bz") || endswith(filename, ".bz2")
+        throw(ArgumentError("BZip2 compression not yet implemented"))
+    end
+
+    if append && isfile(filename) && filesize(filename) > 0
         file_df = readtable(filename, header = false, nrows = 1)
 
         # Check if number of columns matches
@@ -79,7 +83,8 @@ function writetable(filename::String,
             throw(DimensionMismatch("Number of columns differ between file and DataFrame"))
         end
 
-        # In append mode, 'header' triggers a check for matching names
+        # When 'append'-ing to a nonempty file,
+        # 'header' triggers a check for matching colnames
         if header
             if any(i -> symbol(file_df[1, i]) != index(df)[i], 1:size(df, 2))
                 throw(KeyError("Column names don't match names in file"))
@@ -87,10 +92,6 @@ function writetable(filename::String,
 
             header = false
         end
-    end
-
-    if endswith(filename, ".bz") || endswith(filename, ".bz2")
-        throw(ArgumentError("BZip2 compression not yet implemented"))
     end
 
     openfunc = endswith(filename, ".gz") ? gzopen : open

--- a/test/io.jl
+++ b/test/io.jl
@@ -334,9 +334,19 @@ module TestIO
     df3 = DataFrame(a = @data([1, 2, 3]), c = @data([4, 5, 6])) # 2nd column mismatch
     df3b = DataFrame(a = @data([1, 2, 3]), b = @data([4, 5, 6]), c = @data([4, 5, 6])) # number of columns mismatch
 
+
+    # Would use joinpath(tempdir(), randstring()) to get around tempname
+    # creating a file on Windows, but Julia 0.3 has no srand() to unset the
+    # seed set in test/data.jl -- annoying for local testing.
     tf = tempname()
+    isfile(tf) && rm(tf)
 
     # Written as normal if file doesn't exist
+    writetable(tf, df1, append = true)
+    @test readtable(tf) == df1
+
+    # Written as normal if file is empty
+    open(io -> print(io, ""), tf, "w")
     writetable(tf, df1, append = true)
     @test readtable(tf) == df1
 


### PR DESCRIPTION
Empty files are now treated the same as non-existent files in append mode.