### PR TITLE
Updates to reshape

### DIFF
--- a/test/show.jl
+++ b/test/show.jl
@@ -29,8 +29,8 @@ module TestShow
 
     A = DataFrames.StackedVector(Any[[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     show(io, A)
-    A = DataFrames.RepeatedVector([1, 2, 3], 5)
+    A = DataFrames.RepeatedVector([1, 2, 3], 5, 1)
     show(io, A)
-    A = DataFrames.EachRepeatedVector([1, 2, 3], 5)
+    A = DataFrames.RepeatedVector([1, 2, 3], 1, 5)
     show(io, A)
 end


### PR DESCRIPTION
* Update RepeatedVector with both inner and outer arguments.
* Delete EachRepeatedVector (superseded by the new RepeatedVector).
* Add docstrings to reshape.jl.

For the docstrings, they are plain strings without the `@doc...`. These should work with Docile/Lexicon, but I don't think the feature has been put in 0.4, yet. In any case, they don't do anything now. If/when we decide on a docstring format, these can be updated. (Or, I can rip them out if you want.)