### PR TITLE
Allow non-ASCII filenames in read_rda.

### DIFF
--- a/src/RDA.jl
+++ b/src/RDA.jl
@@ -411,7 +411,7 @@ end
 
 read_rda(io::IO; kwoptions...) = read_rda(io, kwoptions)
 
-read_rda(fnm::ASCIIString; kwoptions...) = gzopen(fnm) do io read_rda(io, kwoptions) end
+read_rda(fnm::String; kwoptions...) = gzopen(fnm) do io read_rda(io, kwoptions) end
 
 ##############################################################################
 ##


### PR DESCRIPTION
RDatasets starting giving errors on julia 0.4, which are fixed by this PR.

```
julia> dataset("datasets", "iris")
ERROR: MethodError: `read_rda` has no method matching read_rda(::UTF8String)
 in dataset at /Users/dcjones/.julia/v0.4/RDatasets/src/dataset.jl:6
```