### PR TITLE
Added keyword argument for disabling automatic intercept term in ModelMatrix

### DIFF
--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -282,7 +282,8 @@ end
 
 nc(trm::Vector) = *([size(x,2) for x in trm]...)
 
-function ModelMatrix(mf::ModelFrame)
+function ModelMatrix(mf::ModelFrame; includeIntercept = true)
+	mf.terms.intercept = includeIntercept 
     trms = mf.terms
     aa = Any[Any[ones(size(mf.df,1),int(trms.intercept))]]
     asgn = zeros(Int, (int(trms.intercept)))

--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -282,7 +282,7 @@ end
 
 nc(trm::Vector) = *([size(x,2) for x in trm]...)
 
-function ModelMatrix(mf::ModelFrame; includeIntercept = true)
+function ModelMatrix(mf::ModelFrame; includeIntercept::Bool = true)
 	mf.terms.intercept = includeIntercept 
     trms = mf.terms
     aa = Any[Any[ones(size(mf.df,1),int(trms.intercept))]]


### PR DESCRIPTION
In some regularization methods, the intercept term is handled differently. One wants to penalize the magnitude of coefficients on explanatory variables, but not the intercept, as this would result in different models for data that were simply shifted vertically. 

I added a keyword argument to disable the automatic inclusion of the offset term. I set the default for backwards capability, but in my opinion we probably shouldn't include the intercept unless the user specifically asks for it, as users should probably be centering their own data first anyways. 
