### PR TITLE
fix vcat for empty arrays

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -657,6 +657,7 @@ Base.vcat(df::AbstractDataFrame) = df
 Base.vcat(dfs::AbstractDataFrame...) = vcat(collect(dfs))
 
 function Base.vcat{T<:AbstractDataFrame}(dfs::Vector{T})
+    isempty(dfs) && return dfs
     coltyps, colnams, similars = _colinfo(dfs)
 
     res = DataFrame()

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -656,8 +656,8 @@ Base.vcat(df::AbstractDataFrame) = df
 
 Base.vcat(dfs::AbstractDataFrame...) = vcat(collect(dfs))
 
+Base.vcat(dfs::Vector{None}) = dfs
 function Base.vcat{T<:AbstractDataFrame}(dfs::Vector{T})
-    isempty(dfs) && return dfs
     coltyps, colnams, similars = _colinfo(dfs)
 
     res = DataFrame()

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -46,6 +46,7 @@ module TestCat
     df[1] = 3
     df[:x3] = 2
 
+    vcat([])
     vcat(null_df)
     vcat(null_df, null_df)
     vcat(null_df, df)


### PR DESCRIPTION
Fixes the following:

```jl
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "help()" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.3.8 (2015-04-30 23:40 UTC)
 _/ |\__'_|_|_|\__'_|  |
|__/                   |  x86_64-apple-darwin13.4.0

julia> vcat([])
0-element Array{None,1}

julia> using DataFrames

julia> vcat([])
ERROR: BoundsError()
 in _colinfo at /Users/rene/.julia/v0.3/DataFrames/src/abstractdataframe/abstractdataframe.jl:686
 in vcat at /Users/rene/.julia/v0.3/DataFrames/src/abstractdataframe/abstractdataframe.jl:660
```