### PR TITLE
Implement length(::Cols) for abstract dataframes.

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -90,6 +90,7 @@ end
 Base.start(::Cols) = 1
 Base.done(itr::Cols, st) = st > length(itr.df)
 Base.next(itr::Cols, st) = (itr.df[st], st + 1)
+Base.length(itr::Cols) = length(itr.df)
 
 # N.B. where stored as a vector, 'columns(x) = x.vector' is a bit cheaper
 columns{T <: AbstractDataFrame}(df::T) = Cols{T}(df)


### PR DESCRIPTION
Here's a silly example to reproduce MethodError:

```
DataFrames.by(DataFrame(a=[1,2], b=[3,4]), :a) do r
       DataFrames.by(r, :b) do p
              join(r,p, kind=:left, on=:a)
       end
end
```