### PR TITLE
fixed type error when converting Int64 to Uint8

### DIFF
--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -227,7 +227,7 @@ function dropUnusedLevels!(da::PooledDataArray)
     length(uu) == length(da.pool) && return da
     T = eltype(rr)
     su = sort!(uu)
-    dict = Dict(su, map(T, 1:length(uu)))
+    dict = Dict(su, map(x -> convert(T,x), 1:length(uu)))
     da.refs = map(x -> dict[x], rr)
     da.pool = da.pool[uu]
     da


### PR DESCRIPTION
julia 0.3.8 does not support Uint8(x::Int64), causing an error in the dropUnusedLevels! function. Switched from type constructor to convert invocation to fix.