### PR TITLE
Corrects "local declaration in global scope" (0.4  Commit 1e081b7*)

### DIFF
--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -31,7 +31,7 @@ end
 #' ourstrwidth("abc")
 #' ourstrwidth(10000)
 begin
-    local io = IOBuffer(Array(UInt8, 80), true, true)
+    io = IOBuffer(Array(UInt8, 80), true, true)
     global ourstrwidth
     function ourstrwidth(x::Any) # -> Int
         truncate(io, 0)


### PR DESCRIPTION
Hi,

in Julia 0.4 `Version 0.4.0-dev+5511 (2015-06-22 05:05 UTC)`  **Commit 1e081b7***,
DataFrames does not load (neither does Gadfly) because of **local declaration in global scope** error:

```
julia> using DataFrames
ERROR: LoadError: LoadError: syntax: local declaration in global scope
 in include at ./boot.jl:254
 in include_from_node1 at ./loading.jl:133
 in anonymous at no file:110
 in include at ./boot.jl:254
 in include_from_node1 at ./loading.jl:133
 in reload_path at ./loading.jl:157
 in _require at ./loading.jl:69
 in require at ./loading.jl:52
while loading /home/alain/.julia/v0.4/DataFrames/src/abstractdataframe/show.jl, in expression starting on line 49
while loading /home/alain/.julia/v0.4/DataFrames/src/DataFrames.jl, in expression starting on line 79

```

With proposed patch, it does load, fails `test/runtests.jl` (apparently for other reasons), but runs my Gadfly graphics.
I did not understand the reason for the **local** declaration; if it is needed for other reasons obviously a better patch might be needed