### PR TITLE
predict on dataframes with missing rows

### DIFF
--- a/src/statsmodels/statsmodel.jl
+++ b/src/statsmodels/statsmodel.jl
@@ -68,12 +68,18 @@ typealias DataFrameModels Union(DataFrameStatisticalModel, DataFrameRegressionMo
 # Predict function that takes data frame as predictor instead of matrix
 function StatsBase.predict(mm::DataFrameRegressionModel, df::AbstractDataFrame)
     # copy terms, removing outcome if present (ModelFrame will complain if a
-    # term is not found in the DataFrame)
+    # term is not found in the DataFrame and we don't want to remove elements with missing y)
     newTerms = remove_response(mm.mf.terms)
     # create new model frame/matrix
-    newX = ModelMatrix(ModelFrame(newTerms, df)).m
-    predict(mm, newX)
+    mf = ModelFrame(newTerms, df)
+    newX = ModelMatrix(mf).m
+    yp = predict(mm, newX)
+    out = DataArray(eltype(yp), size(df, 1))
+    out[mf.msng] = yp
+    return(out)
 end
+
+
 
 # coeftable implementation
 function StatsBase.coeftable(model::DataFrameModels)

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -47,6 +47,10 @@ mm = ModelMatrix(ModelFrame(f, d))
 ## new data from DataFrame (via ModelMatrix)
 @test predict(m, d) == predict(m, mm.m)
 
+d2 = deepcopy(d)
+d2[3, :x1] = NA
+@test length(predict(m, d2)) = 4
+
 ## test copying of names from Terms to CoefTable
 ct = coeftable(m)
 @test ct.rownms == ["(Intercept)", "x1", "x2", "x1 & x2"]

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -49,7 +49,7 @@ mm = ModelMatrix(ModelFrame(f, d))
 
 d2 = deepcopy(d)
 d2[3, :x1] = NA
-@test length(predict(m, d2)) = 4
+@test length(predict(m, d2)) == 4
 
 ## test copying of names from Terms to CoefTable
 ct = coeftable(m)


### PR DESCRIPTION
`predict(mm::DataFrameRegressionModel, df::AbstractDataFrame)` currently returns a vector of length lower than `size(df, 1)` when there are missing regressors in the dataframe `df`,

I think it should always return a vector of length equal to `size(df, 1)` (potentially with missing values), so that it remains aligned with the initial dataframe, and so that one can  do
```
df[:yp] = predict(mm, df)
```

I know missing values are currently being redone so this pull request won't impact anything - but this is a general discussion and rewriting the current predict function makes my point clearer.