### PR TITLE
Fix the multicolumn join memory disaster

### DIFF
--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -94,10 +94,12 @@ function DataArrays.PooledDataVecs(df1::AbstractDataFrame,
         for i = 1:length(refs2)
             refs2[i] += (dv2.refs[i]) * ngroups
         end
-        ngroups = ngroups * (length(dv1.pool) + 1)
+        # FIXME check for ngroups overflow, maybe recode refs to prevent it
+        ngroups *= (length(dv1.pool) + 1)
     end
-    pool = [1:ngroups;]
-    (PooledDataArray(DataArrays.RefArray(refs1), pool), PooledDataArray(DataArrays.RefArray(refs2), pool))
+    # recode refs1 and refs2 to drop the unused column combinations and
+    # limit the pool size
+    PooledDataVecs( refs1, refs2 )
 end
 
 function DataArrays.PooledDataArray{R}(df::AbstractDataFrame, ::Type{R})


### PR DESCRIPTION
For joining, the unique combinations of values in the joined columns are indexed in the pooled data array. In the current code the size of the resulting pool is the dramatic overestimation of the actual number of unique combinations (and of the number of rows altogether). Because this pool has to be allocated, it can easily bring the system to the knees even if the joined data frame would only have 1000 rows.

The PR fixes the issue by reindexing the value combinations and allocating the optimal pool.