### PR TITLE
fixed "describe" override for 0.4

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -395,7 +395,7 @@ describe(df)
 ```
 
 """
-describe(df::AbstractDataFrame) = describe(STDOUT, df)
+StatsBase.describe(df::AbstractDataFrame) = describe(STDOUT, df)
 function describe(io, df::AbstractDataFrame)
     for (name, col) in eachcol(df)
         println(io, name)


### PR DESCRIPTION
This gets tests passing for me on 0.3.9 and 0.4-dev

fixes #830
