### PR TITLE
Output to LaTeX added (useful for IJulia notebook export to PDF)

### DIFF
--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -221,7 +221,7 @@ function latex_escape(cell::AbstractString)
     return cell
 end
 
-function Base.writemime(io::IO,
+function Base.show(io::IO,
                         ::MIME"text/latex",
                         df::AbstractDataFrame)
     nrows = size(df, 1)
@@ -242,10 +242,13 @@ function Base.writemime(io::IO,
         for col in 1:ncols
             write(io, " & ")
             cell = df[row,col]
-            if mimewritable(MIME("text/latex"), cell)
-                writemime(io, MIME("text/latex"), cell)
-            else
-                write(io, latex_escape(string(cell)))
+            if !isnull(cell)
+                content = get(cell)
+                if mimewritable(MIME("text/latex"), content)
+                    Base.show(io, MIME("text/latex"), content)
+                else
+                    Base.print(io, latex_escape(string(content)))
+                end
             end
         end
         write(io, " \\\\ \n")

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -221,13 +221,11 @@ function latex_escape(cell::AbstractString)
     return cell
 end
 
-function Base.show(io::IO,
-                        ::MIME"text/latex",
-                        df::AbstractDataFrame)
+function Base.show(io::IO, ::MIME"text/latex", df::AbstractDataFrame)
     nrows = size(df, 1)
     ncols = size(df, 2)
     cnames = _names(df)
-    alignment = join(["c" for _ in 1:ncols])
+    alignment = repeat("c", ncols)
     write(io, "\\begin{tabular}{r|")
     write(io, alignment)
     write(io, "}\n")
@@ -245,9 +243,9 @@ function Base.show(io::IO,
             if !isnull(cell)
                 content = get(cell)
                 if mimewritable(MIME("text/latex"), content)
-                    Base.show(io, MIME("text/latex"), content)
+                    show(io, MIME("text/latex"), content)
                 else
-                    Base.print(io, latex_escape(string(content)))
+                    print(io, latex_escape(string(content)))
                 end
             end
         end

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -216,7 +216,7 @@ function latex_char_escape(char::SubString)
     end
 end
 
-function latex_escape(cell::String)
+function latex_escape(cell::AbstractString)
     cell = replace(cell, ['\\','~','#','$','%','&','_','^','{','}'], latex_char_escape)
     return cell
 end
@@ -232,7 +232,7 @@ function Base.writemime(io::IO,
     write(io, alignment)
     write(io, "}\n")
     write(io, "\t& ")
-    header = join(cnames, " & ")
+    header = join(map(c -> latex_escape(string(c)), cnames), " & ")
     write(io, header)
     write(io, "\\\\ \n")
     write(io, "\t\\hline \n")

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -206,7 +206,7 @@ end
 #
 ##############################################################################
 
-function latex_char_escape(char::SubString)
+function latex_char_escape(char::AbstractString)
     if char == "\\"
         return "\\textbackslash{}"
     elseif char == "~"

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -202,6 +202,37 @@ end
 
 ##############################################################################
 #
+# LaTeX output
+#
+##############################################################################
+
+function Base.writemime(io::IO,
+                        ::MIME"text/latex",
+                        df::AbstractDataFrame)
+    nrows = size(df, 1)
+    ncols = size(df, 2)
+    cnames = _names(df)
+    alignment = join(["c" for _ in 1:ncols])
+    write(io, "\\begin{tabular}{r|")
+    write(io, alignment)
+    write(io, "}\n")
+    write(io, "\t&")
+    header = join(cnames, "&")
+    write(io, header)
+    write(io, "\\\\ \n")
+    write(io, "\t\\hline \n")
+    for row in 1:nrows
+        write(io, "\t")
+        write(io, @sprintf("%d &", row))
+        cell_contents = [string(df[row,col]) for col in 1:ncols]
+        latex_row = join(cell_contents, "&")
+        write(io, latex_row)
+        write(io, "\\\\ \n")
+    end
+    write(io, "\\end{tabular}\n")
+end
+##############################################################################
+#
 # MIME
 #
 ##############################################################################

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -221,16 +221,12 @@ function latex_escape(cell::String)
     return cell
 end
 
-function Base.writemime(io::IO, ::MIME"text/latex", x::Any)
-    write(io, latex_escape(string(x)))
-end
-
 function Base.writemime(io::IO,
                         ::MIME"text/latex",
                         df::AbstractDataFrame)
     nrows = size(df, 1)
     ncols = size(df, 2)
-    cnames = DataFrames._names(df)
+    cnames = _names(df)
     alignment = join(["c" for _ in 1:ncols])
     write(io, "\\begin{tabular}{r|")
     write(io, alignment)
@@ -245,7 +241,12 @@ function Base.writemime(io::IO,
         write(io, @sprintf("%d", row))
         for col in 1:ncols
             write(io, " & ")
-            writemime(io, MIME("text/latex"), df[row,col])
+            cell = df[row,col]
+            if mimewritable(MIME("text/latex"), cell)
+                writemime(io, MIME("text/latex"), cell)
+            else
+                write(io, latex_escape(string(cell)))
+            end
         end
         write(io, " \\\\ \n")
     end

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -206,31 +206,52 @@ end
 #
 ##############################################################################
 
+function latex_char_escape(char::SubString)
+    if char == "\\"
+        return "\\textbackslash{}"
+    elseif char == "~"
+        return "\\textasciitilde{}"
+    else
+        return string("\\", char)
+    end
+end
+
+function latex_escape(cell::String)
+    cell = replace(cell, ['\\','~','#','$','%','&','_','^','{','}'], latex_char_escape)
+    return cell
+end
+
+function Base.writemime(io::IO, ::MIME"text/latex", x::Any)
+    write(io, latex_escape(string(x)))
+end
+
 function Base.writemime(io::IO,
                         ::MIME"text/latex",
                         df::AbstractDataFrame)
     nrows = size(df, 1)
     ncols = size(df, 2)
-    cnames = _names(df)
+    cnames = DataFrames._names(df)
     alignment = join(["c" for _ in 1:ncols])
     write(io, "\\begin{tabular}{r|")
     write(io, alignment)
     write(io, "}\n")
-    write(io, "\t&")
-    header = join(cnames, "&")
+    write(io, "\t& ")
+    header = join(cnames, " & ")
     write(io, header)
     write(io, "\\\\ \n")
     write(io, "\t\\hline \n")
     for row in 1:nrows
         write(io, "\t")
-        write(io, @sprintf("%d &", row))
-        cell_contents = [string(df[row,col]) for col in 1:ncols]
-        latex_row = join(cell_contents, "&")
-        write(io, latex_row)
-        write(io, "\\\\ \n")
+        write(io, @sprintf("%d", row))
+        for col in 1:ncols
+            write(io, " & ")
+            writemime(io, MIME("text/latex"), df[row,col])
+        end
+        write(io, " \\\\ \n")
     end
     write(io, "\\end{tabular}\n")
 end
+
 ##############################################################################
 #
 # MIME

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -2,3 +2,4 @@ Compat 0.9.0
 DataStructures
 RDatasets # can be removed when deprecated.jl doesn't test read_rda anymore
 RData
+LaTeXStrings

--- a/test/io.jl
+++ b/test/io.jl
@@ -498,6 +498,13 @@ module TestIO
                    C = [L"\alpha", L"\beta", L"\gamma", L"\sum_{i=1}^n \delta_i"],
                    D = [1.0, 2.0, Nullable(), 3.0]
                    )
-    @test isequal(reprmime(MIME("text/latex"), df), "\\begin{tabular}{r|cccc}\n\t& A & B & C & D\\\\ \n\t\\hline \n\t1 & 1 & \\\$10.0 & \$\\alpha\$ & 1.0 \\\\ \n\t2 & 2 & M\\&F & \$\\beta\$ & 2.0 \\\\ \n\t3 & 3 & A\\textasciitilde{}B & \$\\gamma\$ &  \\\\ \n\t4 & 4 & \\textbackslash{}alpha & \$\\sum_{i=1}^n \\delta_i\$ & 3.0 \\\\ \n\\end{tabular}\n")
+    @test isequal(reprmime(MIME("text/latex"), df),
+        """\\begin{tabular}{r|cccc}
+	& A & B & C & D\\\\ \n\t\\hline 
+	1 & 1 & \\\$10.0 & \$\\alpha\$ & 1.0 \\\\ 
+	2 & 2 & M\\&F & \$\\beta\$ & 2.0 \\\\ 
+	3 & 3 & A\\textasciitilde{}B & \$\\gamma\$ &  \\\\ 
+	4 & 4 & \\textbackslash{}alpha & \$\\sum_{i=1}^n \\delta_i\$ & 3.0 \\\\ 
+\\end{tabular}\n""")
 
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -499,12 +499,14 @@ module TestIO
                    D = [1.0, 2.0, Nullable(), 3.0]
                    )
     @test isequal(reprmime(MIME("text/latex"), df),
-        """\\begin{tabular}{r|cccc}
-	& A & B & C & D\\\\ \n\t\\hline 
-	1 & 1 & \\\$10.0 & \$\\alpha\$ & 1.0 \\\\ 
-	2 & 2 & M\\&F & \$\\beta\$ & 2.0 \\\\ 
-	3 & 3 & A\\textasciitilde{}B & \$\\gamma\$ &  \\\\ 
-	4 & 4 & \\textbackslash{}alpha & \$\\sum_{i=1}^n \\delta_i\$ & 3.0 \\\\ 
-\\end{tabular}\n""")
-
+            """
+            \\begin{tabular}{r|cccc}
+            \t& A & B & C & D\\\\ 
+            \t\\hline 
+            \t1 & 1 & \\\$10.0 & \$\\alpha\$ & 1.0 \\\\ 
+            \t2 & 2 & M\\&F & \$\\beta\$ & 2.0 \\\\ 
+            \t3 & 3 & A\\textasciitilde{}B & \$\\gamma\$ &  \\\\ 
+            \t4 & 4 & \\textbackslash{}alpha & \$\\sum_{i=1}^n \\delta_i\$ & 3.0 \\\\ 
+            \\end{tabular}
+            """)
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,6 +1,7 @@
 module TestIO
     using Base.Test
     using DataFrames, Compat
+    using LaTeXStrings
 
     #test_group("We can read various file types.")
 
@@ -490,4 +491,13 @@ module TestIO
     # Need to wrap macro call inside eval to prevent the error from being
     # thrown prematurely
     @test_throws ArgumentError eval(:(csv"foo,bar"a))
+
+    # Test LaTeX export
+    df = DataFrame(A = 1:4, 
+                   B = ["\$10.0", "M&F", "A~B", "\\alpha"], 
+                   C = [L"\alpha", L"\beta", L"\gamma", L"\sum_{i=1}^n \delta_i"],
+                   D = [1.0, 2.0, Nullable(), 3.0]
+                   )
+    @test isequal(reprmime(MIME("text/latex"), df), "\\begin{tabular}{r|cccc}\n\t& A & B & C & D\\\\ \n\t\\hline \n\t1 & 1 & \\\$10.0 & \$\\alpha\$ & 1.0 \\\\ \n\t2 & 2 & M\\&F & \$\\beta\$ & 2.0 \\\\ \n\t3 & 3 & A\\textasciitilde{}B & \$\\gamma\$ &  \\\\ \n\t4 & 4 & \\textbackslash{}alpha & \$\\sum_{i=1}^n \\delta_i\$ & 3.0 \\\\ \n\\end{tabular}\n")
+
 end


### PR DESCRIPTION
At the moment DataFrames look great in IJulia (thanks to #433) until they are exported to PDF. This commit adds an additional `writemime` method for the `text/latex` mimetype.