### PR TITLE
Use "multidoc" syntax

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -130,6 +130,15 @@ function names!(df::AbstractDataFrame, vals)
     return df
 end
 
+function rename!(df::AbstractDataFrame, args...)
+    rename!(index(df), args...)
+    return df
+end
+rename!(f::Function, df::AbstractDataFrame) = rename!(df, f)
+
+rename(df::AbstractDataFrame, args...) = rename!(copy(df), args...)
+rename(f::Function, df::AbstractDataFrame) = rename(df, f)
+
 """
 Rename columns
 
@@ -162,17 +171,8 @@ rename(df, :y, :Y)
 rename!(df, @compat(Dict(:i=>:A, :x=>:X)))
 ```
 
-""";
-[:rename!, :rename]
-
-function rename!(df::AbstractDataFrame, args...)
-    rename!(index(df), args...)
-    return df
-end
-rename!(f::Function, df::AbstractDataFrame) = rename!(df, f)
-
-rename(df::AbstractDataFrame, args...) = rename!(copy(df), args...)
-rename(f::Function, df::AbstractDataFrame) = rename(df, f)
+"""
+(rename!, rename)
 
 """
 Column elemental types
@@ -284,6 +284,11 @@ Base.isempty(df::AbstractDataFrame) = ncol(df) == 0
 ##
 ##############################################################################
 
+DataArrays.head(df::AbstractDataFrame, r::Int) = df[1:min(r,nrow(df)), :]
+DataArrays.head(df::AbstractDataFrame) = head(df, 6)
+DataArrays.tail(df::AbstractDataFrame, r::Int) = df[max(1,nrow(df)-r+1):nrow(df), :]
+DataArrays.tail(df::AbstractDataFrame) = tail(df, 6)
+
 """
 Show the first or last part of an AbstractDataFrame
 
@@ -309,13 +314,8 @@ head(df)
 tail(df)
 ```
 
-""";
-[:head, :tail]
-
-DataArrays.head(df::AbstractDataFrame, r::Int) = df[1:min(r,nrow(df)), :]
-DataArrays.head(df::AbstractDataFrame) = head(df, 6)
-DataArrays.tail(df::AbstractDataFrame, r::Int) = df[max(1,nrow(df)-r+1):nrow(df), :]
-DataArrays.tail(df::AbstractDataFrame) = tail(df, 6)
+"""
+(head, tail)
 
 # get the structure of a DF
 """
@@ -587,6 +587,11 @@ function nonunique(df::AbstractDataFrame)
     res
 end
 
+unique!(df::AbstractDataFrame) = deleterows!(df, find(nonunique(df)))
+
+# Unique rows of an AbstractDataFrame.
+Base.unique(df::AbstractDataFrame) = df[!nonunique(df), :]
+
 """
 Delete duplicate rows
 
@@ -614,13 +619,8 @@ unique(df)   # doesn't modify df
 unique!(df)  # modifies df
 ```
 
-""";
-[:unique, :unique!]
-
-unique!(df::AbstractDataFrame) = deleterows!(df, find(nonunique(df)))
-
-# Unique rows of an AbstractDataFrame.
-Base.unique(df::AbstractDataFrame) = df[!nonunique(df), :]
+"""
+(unique, unique!)
 
 function nonuniquekey(df::AbstractDataFrame)
     # Here's another (probably a lot faster) way to do `nonunique`


### PR DESCRIPTION
Fix #852 by using the new v0.4 syntax for documenting multiple things at once.
The downside is that method definitions must precede the documentation block.

CC @simonbyrne 
