### PR TITLE
Avoid overflow

### DIFF
--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -29,4 +29,13 @@ module TestGrouping
     h(df) = g(f(df))
 
     @test combine(map(h, gd)) == combine(map(g, ga))
+
+
+    df = DataFrame(v1 = @data([1, NA, 2, 1]), v2 = @data([1, 3, 2, 1]), v3 = @data([NA, 1, 1, NA]))
+    
+    
+    df = DataFrame(v1 = pool(collect(1:1000)), v2 = pool(fill(1, 1000)))
+    @test groupby(df, [:v1, :v2]).starts == collect(1:1000)
+    @test groupby(df, [:v2, :v1]).starts == collect(1:1000)
+
 end


### PR DESCRIPTION
Correct the following bug : 
```julia 
df = DataFrame(v1 = pool(1:1000), v2 = pool(fill(1, 1000))) 
groupby(df, [:v1, :v2])
```
(initially part of pull request #815)