### PR TITLE
fixes concat deprec warning in allvars(ex::Expr)

### DIFF
--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -57,7 +57,9 @@ end
 ## an expression or a formula
 function allvars(ex::Expr)
     if ex.head != :call error("Non-call expression encountered") end
-    [[allvars(a) for a in ex.args[2:end]]...]
+    cc=Symbol[]
+    for i in ex.args[2:end] cc=vcat(cc,allvars(i)) end
+    cc
 end
 allvars(f::Formula) = unique(vcat(allvars(f.rhs), allvars(f.lhs)))
 allvars(sym::Symbol) = [sym]

--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -58,7 +58,7 @@ end
 function allvars(ex::Expr)
     if ex.head != :call error("Non-call expression encountered") end
     cc=Symbol[]
-    for i in ex.args[2:end] cc=vcat(cc,allvars(i)) end
+    for i in ex.args[2:end] cc=append!(cc,allvars(i)) end
     cc
 end
 allvars(f::Formula) = unique(vcat(allvars(f.rhs), allvars(f.lhs)))


### PR DESCRIPTION
This fixes the concat deprecation warning in DataFrames.allvars(ex:Expr):

WARNING: [a,b] concatenation is deprecated; use [a;b] instead