### PR TITLE
Enhance the DataFrame keyword constructor to recycle

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -98,10 +98,35 @@ type DataFrame <: AbstractDataFrame
     end
 end
 
+# Return an AbstractVector of length `len` filled with `x`.
+# `x` is returned as is if it is `length(x)` == `len`.
+# If `x` is of length 1, recycle to length `len`.
+rep_len(x, len) = rep([x], len)
+function rep_len(x::AbstractVector, len)
+    if length(x) == len
+        return x
+    elseif length(x) == 1 
+        return rep(x, len)
+    else
+        error("inappropriate lengths")
+    end
+end
+
 function DataFrame(; kwargs...)
     result = DataFrame(Any[], Index())
+    if length(kwargs) == 0
+        return result
+    end
+    len = mapreduce(x -> length(x[2]), max, kwargs)
+    if len == 0
+        return DataFrame(Any[kv[2] for kv in kwargs], 
+                         Symbol[kv[1] for kv in kwargs])
+    end
     for (k, v) in kwargs
-        result[k] = v
+        if length(v) != 1 && length(v) != len 
+            error("Incompatible lengths of arguments")
+        end
+        result[k] = rep_len(v, len)
     end
     return result
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -37,6 +37,12 @@ module TestConstructors
     @test isequal(df, DataFrame(x1 = [0.0, 0.0, 0.0],
                                 x2 = [1.0, 1.0, 1.0],
                                 x3 = [2.0, 2.0, 2.0])[[:x1, :x2]])
+    @test isequal(df, DataFrame(x1 = 0.0,
+                                x2 = [1.0, 1.0, 1.0]))
+    @test isequal(df, DataFrame(x1 = [0.0, 0.0, 0.0],
+                                x2 = 1.0))
+    @test isequal(df, DataFrame(x1 = [0.0],
+                                x2 = [1.0, 1.0, 1.0]))
 
     df = DataFrame(Int, 2, 2)
     @test size(df) == (2, 2)


### PR DESCRIPTION
This fixes an issue with the `DataFrame` constructor with keyword arguments. This comes up when using `by`, particularly with DataFramesMeta use. Here is the issue:

``` julia
julia> DataFrame(a = 1:5, b = 1)
5x2 DataFrames.DataFrame
| Row | a | b |
|-----|---|---|
| 1   | 1 | 1 |
| 2   | 2 | 1 |
| 3   | 3 | 1 |
| 4   | 4 | 1 |
| 5   | 5 | 1 |

julia> DataFrame(a = 1, b = 1:5)
ERROR: New columns must have the same length as old columns
 in insert_single_column! at /home/tshort/.julia/v0.4/DataFrames/src/dataframe/dataframe.jl:309
 in setindex! at /home/tshort/.julia/v0.4/DataFrames/src/dataframe/dataframe.jl:368
 in DataFrame at /home/tshort/.julia/v0.4/DataFrames/src/dataframe/dataframe.jl:104
```

Here are results with this PR:

``` julia
julia> DataFrame(a = 1, b = 1:5)
5x2 DataFrames.DataFrame
| Row | a | b |
|-----|---|---|
| 1   | 1 | 1 |
| 2   | 1 | 2 |
| 3   | 1 | 3 |
| 4   | 1 | 4 |
| 5   | 1 | 5 |

julia> DataFrame(a = 1:5, b = 1)
5x2 DataFrames.DataFrame
| Row | a | b |
|-----|---|---|
| 1   | 1 | 1 |
| 2   | 2 | 1 |
| 3   | 3 | 1 |
| 4   | 4 | 1 |
| 5   | 5 | 1 |

julia> DataFrame(a = 1:5, b = 1:3)
5x2 DataFrames.DataFrame
| Row | a | b |
|-----|---|---|
| 1   | 1 | 1 |
| 2   | 2 | 2 |
| 3   | 3 | 3 |
| 4   | 4 | 1 |
| 5   | 5 | 2 |
```

Note that this doesn't change the lack of recycling for other methods.
