### PR TITLE
Correct a bug in a different unstack method

### DIFF
--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -187,7 +187,7 @@ function unstack(df::AbstractDataFrame, rowkey::Int, colkey::Int, value::Int)
             payload[j][i]  = valuecol[k]
         end
     end
-    insert!(payload, 1, refkeycol.pool, _names(df)[colkey])
+    insert!(payload, 1, refkeycol.pool, _names(df)[rowkey])
 end
 unstack(df::AbstractDataFrame, rowkey, colkey, value) =
     unstack(df, index(df)[rowkey], index(df)[colkey], index(df)[value])

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -301,8 +301,12 @@ module TestDataFrame
     df = DataFrame(Fish = ["Bob", "Bob", "Batman", "Batman"], 
         Key = ["Mass", "Color", "Mass", "Color"], 
         Value = ["12 g", "Red", "18 g", "Grey"])
+    #Unstack specifying a row column
     df2 = unstack(df,:Fish, :Key, :Value)
+    #Unstack without specifying a row column
+    df3 = unstack(df,:Key, :Value)
     #The expected output
-    df3 = DataFrame(Key = ["Batman", "Bob"], Color = ["Grey", "Red"], Mass = ["18 g", "12 g"])
-    @test df2 == df3
+    df4 = DataFrame(Fish = ["Batman", "Bob"], Color = ["Grey", "Red"], Mass = ["18 g", "12 g"])
+    @test df2 == df4
+    @test df3 == df4
 end


### PR DESCRIPTION
This fixes column names in unstack when called without a key column.
Also added a test for this method.