### PR TITLE
vcat: NA should be promoted to any type

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -686,7 +686,7 @@ function Base.vcat{T<:AbstractDataFrame}(dfs::Vector{T})
 
         i = 1
         for df in dfs
-            if haskey(df, colnam)
+            if haskey(df, colnam) && eltype(df[colnam]) != NAtype
                 copy!(col, i, df[colnam])
             end
             i += size(df, 1)

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -676,6 +676,7 @@ Base.vcat(dfs::AbstractDataFrame...) = vcat(collect(dfs))
 
 Base.vcat(dfs::Vector{Void}) = dfs
 function Base.vcat{T<:AbstractDataFrame}(dfs::Vector{T})
+    isempty(dfs) && return DataFrame()
     coltyps, colnams, similars = _colinfo(dfs)
 
     res = DataFrame()

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -81,6 +81,7 @@ module TestCat
 
     # Eltype promotion
     @test eltypes(vcat(DataFrame(a = [1]), DataFrame(a = [2.1]))) == [Float64]
+    @test eltypes(vcat(DataFrame(a = [NA]), DataFrame(a = [2.1]))) == [Float64]
 
     # Minimal container type promotion
     dfa = DataFrame(a = @pdata([1, 2, 2]))

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -57,6 +57,7 @@ module TestCat
     vcat(df, null_df)
     vcat(df, df)
     vcat(df, df, df)
+    @test vcat(DataFrame[]) == DataFrame()
 
     alt_df = deepcopy(df)
     vcat(df, alt_df)


### PR DESCRIPTION
vcat should not try to copy data from a DataArray that only contains missing values.