### PR TITLE
Join reftype

### DIFF
--- a/test/join.jl
+++ b/test/join.jl
@@ -66,4 +66,17 @@ module TestJoin
 
     # Cross joins don't take keys
     @test_throws ArgumentError join(df1, df2, on = :A, kind = :cross)
+
+    # Reftype is needed for joins on several columns and several rows
+    N = 10000
+    dfc1 = DataFrame(A = 1:N, B=1:N, C=1:N, dfc1=ones(N))
+    dfc2 = DataFrame(A = 1:N, B=1:N, C=1:N, dfc2=2*ones(N))
+
+    try
+        join(dfc1, dfc2, on=[:A,:B,:C])
+    catch x
+        @test isa(x,InexactError)
+    end
+
+    join(dfc1, dfc2, on=[:A,:B,:C], reftype=BigInt)
 end

--- a/test/join.jl
+++ b/test/join.jl
@@ -72,11 +72,6 @@ module TestJoin
     dfc1 = DataFrame(A = 1:N, B=1:N, C=1:N, dfc1=ones(N))
     dfc2 = DataFrame(A = 1:N, B=1:N, C=1:N, dfc2=2*ones(N))
 
-    try
-        join(dfc1, dfc2, on=[:A,:B,:C])
-    catch x
-        @test isa(x,InexactError)
-    end
-
+    @test_throws InexactError join(dfc1, dfc2, on=[:A,:B,:C])
     join(dfc1, dfc2, on=[:A,:B,:C], reftype=BigInt)
 end


### PR DESCRIPTION
join: let the user specify a larger reftype if DEFAULT_POOLED_REF_TYPE isn't large enough

It would be possible to add a detection for when larger datatypes are needed:

prod([length(unique(df1[c]))+length(unique(df2[c]))+1 for c=on]) > typemax(DataArrays.DEFAULT_POOLED_REF_TYPE)
