### PR TITLE
removed hidden unstack function that was never called

### DIFF
--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -199,21 +199,6 @@ unstack(df::AbstractDataFrame, colkey, value) =
 function unstack(df::AbstractDataFrame, colkey::Int, value::Int)
     # group on anything not a key or value:
     g = groupby(df, setdiff(_names(df), _names(df)[[colkey, value]]))
-    # find the indexes for each group:
-    groupidxs = [g.idx[g.starts[i]:g.ends[i]] for i in 1:length(g.starts)]
-    # this will be a new column to key the rows:
-    rowkey = PooledDataArray(zeros(Int, size(df, 1)), [1:length(groupidxs);])
-    for i in 1:length(groupidxs)
-        rowkey[groupidxs[i]] = i
-    end
-    df2 = copy(df)
-    df2[gensym()] = rowkey
-    unstack(df2, length(df2), colkey, value)
-end
-
-function unstack(df::AbstractDataFrame, colkey::Int, value::Int)
-    # group on anything not a key or value:
-    g = groupby(df, setdiff(_names(df), _names(df)[[colkey, value]]))
     groupidxs = [g.idx[g.starts[i]:g.ends[i]] for i in 1:length(g.starts)]
     rowkey = PooledDataArray(zeros(Int, size(df, 1)), [1:length(groupidxs);])
     for i in 1:length(groupidxs)


### PR DESCRIPTION
Two functions share the signature:
```function unstack(df::AbstractDataFrame, colkey::Int, value::Int)```

Both functions were added in d0d7ff7f99d9713fad97dac2e1b637c4571f4684