### PR TITLE
make name normalization optional

### DIFF
--- a/test/io.jl
+++ b/test/io.jl
@@ -327,6 +327,10 @@ module TestIO
     io = IOBuffer(abnormal*",%_B*\tC*,end\n1,2,3\n")
     @test names(readtable(io)) == ns
 
+    # With normalization disabled
+    io = IOBuffer(abnormal*",%_B*\tC*,end\n1,2,3\n")
+    @test names(readtable(io, normalizenames=false)) == [symbol(abnormal),symbol("%_B*\tC*"),:end]
+
     # Test writetable with NA and compare to the results
     tf = tempname()
     isfile(tf) && rm(tf)


### PR DESCRIPTION
Silently altering the column names of a file is not always desired. This PR adds an option to turn it off in when calling readtable.