### PR TITLE
Do not print quotemark if it is null

### DIFF
--- a/docs/io.md
+++ b/docs/io.md
@@ -61,6 +61,6 @@ Additional advanced options are documented below.
 `writetable` accepts the following optional keyword arguments:
 
 -   `separator::Char` -- The separator character that you would like to use. Defaults to the output of `getseparator(filename)`, which uses commas for files that end in `.csv`, tabs for files that end in `.tsv` and a single space for files that end in `.wsv`.
--   `quotemark::Char` -- The character used to delimit string fields. Defaults to `'"'`.
+-   `quotemark::Char` -- The character used to delimit string fields. Defaults to `'"'`. Use `'\0'` to omit `quotemark`.
 -   `header::Bool` -- Should the file contain a header that specifies the column names from `df`. Defaults to `true`.
 

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -23,9 +23,9 @@ function printtable(io::IO,
     if header
         cnames = _names(df)
         for j in 1:p
-            print(io, quotemark)
+            if quotemark != '\0' print(io, quotemark) end
             print(io, cnames[j])
-            print(io, quotemark)
+            if quotemark != '\0' print(io, quotemark) end
             if j < p
                 print(io, separator)
             else
@@ -37,9 +37,9 @@ function printtable(io::IO,
         for j in 1:p
             if ! (isna(df[j],i))
                 if ! (etypes[j] <: Real)
-		    print(io, quotemark)
+		    if quotemark != '\0' print(io, quotemark) end
 		    escapedprint(io, df[i, j], "\"'")
-		    print(io, quotemark)
+		    if quotemark != '\0' print(io, quotemark) end
                 else
 		    print(io, df[i, j])
                 end


### PR DESCRIPTION
This is to provide a way to omit quotemark when output data.

The interface of  `writetable` is not changed, if `quotemark='\0'` is given in the parameter of `writetable()` function, then the quotemark is not printed.

This feature is very useful for outputing file formarts requring no quotemark, like VCF: http://samtools.github.io/hts-specs/VCFv4.1.pdf

VCF is heavily used in bioinformatics. And we shouldn't use quotemark for outputing VCF.

I have tested this change well with OpenGene.jl project (https://github.com/OpenGene/OpenGene.jl)