### PR TITLE
Adds column preselection for readtable ('usecols')

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -83,6 +83,9 @@ Advanced Options for Reading CSV Files
 - ``skipblanks::Bool`` -- Skip any blank lines in input. Defaults to ``true``.
 - ``encoding::Symbol`` -- Specify the file's encoding as either ``:utf8`` or
   ``:latin1``. Defaults to ``:utf8``.
+- ``usecols::Union{Vector{Symbol},Vector{Int}}`` -- Only read subset of columns.
+  Columns may be specified by either a list of indices (e.g. ``[1,2,3,5,8]``) or
+  a list of names (e.g. ``[:x1,:x3]``). Default: read all columns.
 
 Advanced Options for Writing CSV Files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/io.md
+++ b/docs/io.md
@@ -55,6 +55,7 @@ Additional advanced options are documented below.
 -   `skiprows::Vector{Int}` -- Specify the indices of lines in the input to ignore. Defaults to `[]`.
 -   `skipblanks::Bool` -- Skip any blank lines in input. Defaults to `true`.
 -   `encoding::Symbol` -- Specify the file's encoding as either `:utf8` or `:latin1`. Defaults to `:utf8`.
+-   `usecols::Union{Vector{Symbol},Vector{Int}}` -- Only read subset of columns.  Columns may be specified by either a list of indices (e.g. `[1,2,3,5,8]`) or a list of names (e.g. `[:x1,:x3]`). Default: read all columns.
 
 ## Advanced Options for Writing CSV Files
 

--- a/src/dataframe/io.jl
+++ b/src/dataframe/io.jl
@@ -25,7 +25,7 @@ immutable ParseOptions{S <: ByteString}
     encoding::Symbol
     allowescapes::Bool
     normalizenames::Bool
-    usecols::Union{Vector{Symbol},Vector{Int}}
+    usecols::@compat(Union{Vector{Symbol},Vector{Int}})
 end
 
 # Dispatch on values of ParseOptions to avoid running
@@ -848,7 +848,7 @@ function readtable(io::IO,
                    encoding::Symbol = :utf8,
                    allowescapes::Bool = false,
                    normalizenames::Bool = true,
-                   usecols::Union{Vector{Symbol},Vector{Int}} = Int[])
+                   usecols::@compat(Union{Vector{Symbol},Vector{Int}}) = Int[])
     if encoding != :utf8
         throw(ArgumentError("Argument 'encoding' only supports ':utf8' currently."))
     elseif !isempty(skiprows)
@@ -916,7 +916,7 @@ function readtable(pathname::AbstractString;
                    encoding::Symbol = :utf8,
                    allowescapes::Bool = false,
                    normalizenames::Bool = true,
-                   usecols::Union{Vector{Symbol},Vector{Int}} = Int[])
+                   usecols::@compat(Union{Vector{Symbol},Vector{Int}}) = Int[])
     # Open an IO stream based on pathname
     # (1) Path is an HTTP or FTP URL
     if startswith(pathname, "http://") || startswith(pathname, "ftp://")

--- a/src/dataframe/io.jl
+++ b/src/dataframe/io.jl
@@ -25,6 +25,7 @@ immutable ParseOptions{S <: ByteString}
     encoding::Symbol
     allowescapes::Bool
     normalizenames::Bool
+    usecols::Union{Vector{Symbol},Vector{Int}}
 end
 
 # Dispatch on values of ParseOptions to avoid running
@@ -505,9 +506,38 @@ function builddf(rows::Integer,
                  fields::Integer,
                  p::ParsedCSV,
                  o::ParseOptions)
-    columns = Array(Any, cols)
+    # Determine column names
+    if isempty(o.names)
+        names = gennames(cols)
+    else
+        names = copy(o.names)
+    end
+    # Determine columns to be read from usecols-option
+    # If option not set: read all available columns
+    if isempty(o.usecols)
+        colindices = 1:cols
+    else
+        if isa(o.usecols, Vector{Int})
+            colindices = indexin(o.usecols, 1:cols)
+        else
+            colindices = indexin(o.usecols, names)
+        end
+        if any(colindices .== 0)
+            errorcols = map(x->string(x), o.usecols[colindices .== 0])
+            errorcols = join(errorcols, ", ")
+            error("usecols: invalid column(s): $errorcols")
+        else
+            # Select columns only once and in order of original dataset
+            colindices = sort(unique(colindices))
+        end
+        # Filter names for selected columns
+        names = names[colindices]
+    end
+    columns = Array(Any, length(colindices))
 
-    for j in 1:cols
+    # k: new column index in data frame
+    # j: old column index in original data
+    for (k, j) in enumerate(colindices)
         if isempty(o.eltypes)
             values = Array(Int, rows)
         else
@@ -640,17 +670,13 @@ function builddf(rows::Integer,
         end
 
         if o.makefactors && !(is_int || is_float || is_bool)
-            columns[j] = PooledDataArray(values, missing)
+            columns[k] = PooledDataArray(values, missing)
         else
-            columns[j] = DataArray(values, missing)
+            columns[k] = DataArray(values, missing)
         end
     end
 
-    if isempty(o.names)
-        return DataFrame(columns, gennames(cols))
-    else
-        return DataFrame(columns, o.names)
-    end
+    return DataFrame(columns, names)
 end
 
 function parsenames!(names::Vector{Symbol},
@@ -821,7 +847,8 @@ function readtable(io::IO,
                    skipblanks::Bool = true,
                    encoding::Symbol = :utf8,
                    allowescapes::Bool = false,
-                   normalizenames::Bool = true)
+                   normalizenames::Bool = true,
+                   usecols::Union{Vector{Symbol},Vector{Int}} = Int[])
     if encoding != :utf8
         throw(ArgumentError("Argument 'encoding' only supports ':utf8' currently."))
     elseif !isempty(skiprows)
@@ -856,7 +883,7 @@ function readtable(io::IO,
                      makefactors, names, eltypes,
                      allowcomments, commentmark, ignorepadding,
                      skipstart, skiprows, skipblanks, encoding,
-                     allowescapes, normalizenames)
+                     allowescapes, normalizenames, usecols)
 
     # Use the IO stream method for readtable()
     df = readtable!(p, io, nrows, o)
@@ -888,7 +915,8 @@ function readtable(pathname::AbstractString;
                    skipblanks::Bool = true,
                    encoding::Symbol = :utf8,
                    allowescapes::Bool = false,
-                   normalizenames::Bool = true)
+                   normalizenames::Bool = true,
+                   usecols::Union{Vector{Symbol},Vector{Int}} = Int[])
     # Open an IO stream based on pathname
     # (1) Path is an HTTP or FTP URL
     if startswith(pathname, "http://") || startswith(pathname, "ftp://")
@@ -927,7 +955,8 @@ function readtable(pathname::AbstractString;
                      skipblanks = skipblanks,
                      encoding = encoding,
                      allowescapes = allowescapes,
-                     normalizenames = normalizenames)
+                     normalizenames = normalizenames,
+                     usecols = usecols)
 end
 
 function filldf!(df::DataFrame,
@@ -946,6 +975,8 @@ function filldf!(df::DataFrame,
         end
     end
 
+    #TODO implement 'usecols'-options
+    #     (if necessary; filldf! does not seem to be used anywhere...) 
     for j in 1:cols
         c = df.columns[j]
         T = etypes[j]

--- a/test/io.jl
+++ b/test/io.jl
@@ -282,6 +282,45 @@ module TestIO
     @test df[:c5][2] == "true"
     @test df[:c5][3] == "true"
 
+
+    # Readtable column preselection ('usecols')
+    filename = "$data/typeinference/standardtypes.csv"
+    df = readtable(filename)
+    @test size(df) == (3,5)
+
+    df = readtable(filename, usecols=[1,3,5])
+    @test size(df) == (3,3)
+    @test df[1] == df[:IntColumn] == [1,2,-1]
+    @test df[2] == df[:FloatColumn] == [3.1,-3.1e8,-3.1e-8]
+    @test df[3] == df[:StringColumn] == ["stuff","blah","gah"]
+
+    df = readtable(filename, usecols=[:IntlikeColumn,:BoolColumn])
+    @test size(df) == (3,2)
+    @test df[1] == df[:IntlikeColumn] == [1.0,7.0,7.0]
+    @test df[2] == df[:BoolColumn] == [true,false,false]
+
+    df = readtable(filename, usecols=[:x1,:x2,:x3], header=false, skipstart=1)
+    @test size(df) == (3,3)
+    @test df[1] == df[:x1] == [1,2,-1]
+    @test df[2] == df[:x2] == [1.0,7.0,7.0]
+    @test df[3] == df[:x3] == [3.1,-3.1e8,-3.1e-8]
+
+    df = readtable(filename, usecols=[5,3,1,3])
+    @test size(df) == (3,3)
+    @test df[1] == df[:IntColumn] == [1,2,-1]
+    @test df[2] == df[:FloatColumn] == [3.1,-3.1e8,-3.1e-8]
+    @test df[3] == df[:StringColumn] == ["stuff","blah","gah"]
+
+    df = readtable(filename, usecols=[:x3,:x1,:x1], header=false, skipstart=1)
+    @test size(df) == (3,2)
+    @test df[1] == df[:x1] == [1,2,-1]
+    @test df[2] == df[:x3] == [3.1,-3.1e8,-3.1e-8]
+
+    @test_throws ErrorException readtable(filename, usecols=[1,2,10,100,101])
+    @test_throws ErrorException readtable(filename, usecols=[:BoolColumn, :BocciaColumn])
+
+
+
     # Readtable defining column types
     filename = "$data/definedtypes/mixedvartypes.csv"
 


### PR DESCRIPTION
Hi,
I recently implemented a 'usecols' option for readtable.
It is designed analogously to the according read_csv-option in pandas.
It has especially high value when working with huge data files, whose complete parsing would fill the entire RAM...

'usecols' expects one of two kinds of values: either Vector{Int} with column indices (e.g. [1,3,4] for first, third and fourth columns), or Vector{Symbol} with column names.
Column names are previously parse, thus one can either use the names as defined in a header, manually defined names, or automatically defined symbols (e.g. :x1, :x2, ...).

If an attempt is done to read a non-existing column, an appropriate error is thrown.

The commits include the updated source, documentation and tests.

Fixes issues #605 and #568.

Open question: There is a 'filldf!' function, which looks awfully similar to 'builddf'.
However, it does not seem to be used anywhere and is not exported. Thus, I have not implemented 'usecols' for it. Was that a misjudgement? It would be easy for me, to adapt 'filldf!', too.
Feedback welcome.

Cheers,
  Florian
