### PR TITLE
Fix tty_cols()/tty_rows() deprecation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,5 +4,5 @@ StatsBase 0.3.9+
 GZip
 SortingAlgorithms
 Reexport
-Compat 0.7.9
+Compat 0.7.12
 Docile


### PR DESCRIPTION
Fixes #907.

This can either be merged as-is, or wait for a new version of Compat with support for `displaysize` to be tagged (cf. https://github.com/JuliaLang/Compat.jl/pull/172).