### PR TITLE
Adding macro df_str

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 julia:
   - nightly
   - 0.4
-  - 0.3
 os:
   - linux
   - osx

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3.4-
+julia 0.4
 DataArrays 0.2.15
 StatsBase 0.3.9+
 GZip

--- a/docs/io.md
+++ b/docs/io.md
@@ -12,7 +12,7 @@ df = readtable("data.txt", separator = '\t')
 df = readtable("data.txt", header = false)
 ```
 
-`readtable` requires that you specify the path of the file that you would like to read as a `String`. It supports many additional keyword arguments: these are documented in the section on advanced I/O operations.
+`readtable` requires that you specify the path of the file that you would like to read as a `String`. To read data from a non-file source, you may also supply an `IO` object. It supports many additional keyword arguments: these are documented in the section on advanced I/O operations.
 
 ## Exporting data to a tabular data file
 
@@ -66,3 +66,52 @@ Additional advanced options are documented below.
 -   `header::Bool` -- Should the file contain a header that specifies the column names from `df`. Defaults to `true`.
 -   `nastring::AbstractString` -- What to write in place of missing data. Defaults to `"NA"`.
 
+## Supplying `DataFrame`s inline with non-standard string literals
+
+You can also provide CSV-like tabular data in a non-standard string literal to construct a new `DataFrame`, as in the following:
+
+```julia
+df = csv"""
+    name,  age, squidPerWeek
+    Alice,  36,         3.14
+    Bob,    24,         0
+    Carol,  58,         2.71
+    Eve,    49,         7.77
+    """
+```
+
+The `csv` string literal prefix indicates that the data are supplied in standard comma-separated value format. Common alternative formats are also available as string literals. For semicolon-separated values, with comma as a decimal, use `csv2`:
+
+```julia
+df = csv2"""
+    name;  age; squidPerWeek
+    Alice;  36;         3,14
+    Bob;    24;         0
+    Carol;  58;         2,71
+    Eve;    49;         7,77
+    """
+```
+
+For whitespace-separated values, use `wsv`:
+
+```julia
+df = wsv"""
+    name  age squidPerWeek
+    Alice  36         3.14
+    Bob    24         0
+    Carol  58         2.71
+    Eve    49         7.77
+    """
+```
+
+And for tab-separated values, use `tsv`:
+
+```julia
+df = tsv"""
+    name	age	squidPerWeek
+    Alice	36	3.14
+    Bob	24	0
+    Carol	58	2.71
+    Eve	49	7.77
+    """
+```

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -26,6 +26,10 @@ using Docile
 ##############################################################################
 
 export @~,
+       @csv_str,
+       @csv2_str,
+       @tsv_str,
+       @wsv_str,
 
        AbstractDataFrame,
        DataFrame,


### PR DESCRIPTION
I find it handy to have a macro to wrap `readtable` to make it easy to include small-to-medium amounts of data directly alongside code as a nonstandard string literal.  E.g., instead of writing

```julia
data = DataFrame(
    name=["Alice","Bob","Carol","Eve"],
    age=[36,24,58,49],
    numPetSquid=[3,0,2,7])
```

one can instead write

```julia
data = df"""
    name,  age, numPetSquid
    Alice,  36,           3
    Bob,    24,           0
    Carol,  58,           2
    Eve,    49,           7"""
```

This seems like a common enough need/convenience that I thought it was worth suggesting as an addition to the package. I'm pretty inexperienced at contributing patches, so please let me know if it seems like a worthwhile idea but needs improvement for inclusion.