### PR TITLE
Delegate new functions for statistical models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 julia:
   - nightly
   - 0.4
-  - 0.3
 os:
   - linux
   - osx

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.4
 DataArrays 0.2.15
-StatsBase 0.3.9+
+StatsBase v0.8.0
 GZip
 SortingAlgorithms
 Reexport

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3.4-
+julia 0.4
 DataArrays 0.2.15
 StatsBase 0.3.9+
 GZip

--- a/src/statsmodels/statsmodel.jl
+++ b/src/statsmodels/statsmodel.jl
@@ -59,11 +59,18 @@ end
 
 # Delegate functions from StatsBase that use our new types
 typealias DataFrameModels @compat(Union{DataFrameStatisticalModel, DataFrameRegressionModel})
-@delegate DataFrameModels.model [StatsBase.coef, StatsBase.confint, StatsBase.deviance,
-                                 StatsBase.loglikelihood, StatsBase.nobs, StatsBase.stderr,
-                                 StatsBase.vcov]
+@delegate DataFrameModels.model [StatsBase.coef, StatsBase.confint,
+                                 StatsBase.deviance, StatsBase.nulldeviance,
+                                 StatsBase.loglikelihood, StatsBase.nullloglikelihood,
+                                 StatsBase.df, StatsBase.df_residual, StatsBase.nobs,
+                                 StatsBase.stderr, StatsBase.vcov]
 @delegate DataFrameRegressionModel.model [StatsBase.residuals, StatsBase.model_response,
                                           StatsBase.predict, StatsBase.predict!]
+# Need to define these manually because of ambiguity using @delegate
+StatsBase.R2(mm::DataFrameRegressionModel) = R2(mm.model)
+StatsBase.adjR2(mm::DataFrameRegressionModel) = adjR2(mm.model)
+StatsBase.R2(mm::DataFrameRegressionModel, variant::Symbol) = R2(mm.model, variant)
+StatsBase.adjR2(mm::DataFrameRegressionModel, variant::Symbol) = adjR2(mm.model, variant)
 
 # Predict function that takes data frame as predictor instead of matrix
 function StatsBase.predict(mm::DataFrameRegressionModel, df::AbstractDataFrame)


### PR DESCRIPTION
These were just added to StatsBase (https://github.com/JuliaStats/StatsBase.jl/pull/146).

Tests won't pass until we tag a new StatsBase release. This PR is required to actually implement these functions in GLM.jl (https://github.com/JuliaStats/GLM.jl/pull/115), since tests there need methods working on `DataFrameRegressionModel`.