### PR TITLE
Fix falsestrings doc description for readtable

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -63,7 +63,7 @@ Advanced Options for Reading CSV Files
 - ``truestrings::Vector{ASCIIString}`` -- Translate any of the strings into
   this vector into a Boolean ``true``. Defaults to ``["T", "t", "TRUE", "true"]``.
 - ``falsestrings::Vector{ASCIIString}`` -- Translate any of the strings into
-  this vector into a Boolean ``true``. Defaults to ``["F", "f", "FALSE", "false"]``.
+  this vector into a Boolean ``false``. Defaults to ``["F", "f", "FALSE", "false"]``.
 - ``makefactors::Bool`` -- Convert string columns into ``PooledDataVector``'s
   for use as factors. Defaults to ``false``.
 - ``nrows::Int`` -- Read only ``nrows`` from the file. Defaults to ``-1``, which


### PR DESCRIPTION
The description of the falsestrings::Vector{ASCIIString} option in the documentation has been changed to indicate that the strings in the vector represent a Boolean false instead of a Boolean true.