### PR TITLE
Changed printtable to escape only the quotemark character.

### DIFF
--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -33,12 +33,13 @@ function printtable(io::IO,
             end
         end
     end
+    quotestr = string(quotemark)
     for i in 1:n
         for j in 1:p
             if ! (isna(df[j],i))
                 if ! (etypes[j] <: Real)
 		    print(io, quotemark)
-		    escapedprint(io, df[i, j], "\"'")
+		    escapedprint(io, df[i, j], quotestr)
 		    print(io, quotemark)
                 else
 		    print(io, df[i, j])

--- a/test/io.jl
+++ b/test/io.jl
@@ -397,6 +397,6 @@ module TestIO
 
     # Make sure the ' does get escaped when needed
     writetable(tf, df, quotemark='\'')
-    @test open(readall, tf) == "'a'\n'who\\'s'\n"
+    @test readstring(tf) == "'a'\n'who\\'s'\n"
 
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -384,4 +384,19 @@ module TestIO
     # Enforces matching column count if append == true
     writetable(tf, df3)
     @test_throws DimensionMismatch writetable(tf, df3b, header = false, append = true)
+
+    # Quotemarks are escaped
+    tf = tempname()
+    isfile(tf) && rm(tf)
+
+    df = DataFrame(a = ["who's"]) # We have a ' in our string
+
+    # Make sure the ' doesn't get escaped for no reason
+    writetable(tf, df)
+    @test readtable(tf) == df
+
+    # Make sure the ' does get escaped when needed
+    writetable(tf, df, quotemark='\'')
+    @test open(readall, tf) == "'a'\n'who\\'s'\n"
+
 end


### PR DESCRIPTION
 Previously, single and double quotes were escaped regardless of the quotemark.

Added two related unit tests to avoid future regression