### PR TITLE
Fix DataFrameRow's getindex deprecation warning.

### DIFF
--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -5,7 +5,7 @@ immutable DataFrameRow{T <: AbstractDataFrame}
 end
 
 function Base.getindex(r::DataFrameRow, idx::AbstractArray)
-    return DataFrameRow(r.df[[idx]], r.row)
+    return DataFrameRow(r.df[idx], r.row)
 end
 
 function Base.getindex(r::DataFrameRow, idx::Any)


### PR DESCRIPTION
In Julia 0.4.3 indexing into DataFrameRows with some child of AbstractArray produced a deprecation warning. This should now be fixed.