### PR TITLE
Remove nonstandard v from version number in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.4
 DataArrays 0.2.15
-StatsBase v0.8.0
+StatsBase 0.8.0
 GZip
 SortingAlgorithms
 Reexport


### PR DESCRIPTION
This works, but may as well be consistent