### PR TITLE
vcat collect type

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -673,7 +673,7 @@ Base.hcat(df::AbstractDataFrame, x, y...) = hcat!(hcat(df, x), y...)
 
 Base.vcat(df::AbstractDataFrame) = df
 
-Base.vcat(dfs::AbstractDataFrame...) = vcat(collect(AbstractDataFrame, dfs))
+Base.vcat(dfs::AbstractDataFrame...) = vcat(AbstractDataFrame[dfs...])
 
 Base.vcat(dfs::Vector{Void}) = dfs
 function Base.vcat{T<:AbstractDataFrame}(dfs::Vector{T})

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -673,7 +673,7 @@ Base.hcat(df::AbstractDataFrame, x, y...) = hcat!(hcat(df, x), y...)
 
 Base.vcat(df::AbstractDataFrame) = df
 
-Base.vcat(dfs::AbstractDataFrame...) = vcat(collect(dfs))
+Base.vcat(dfs::AbstractDataFrame...) = vcat(collect(AbstractDataFrame, dfs))
 
 Base.vcat(dfs::Vector{Void}) = dfs
 function Base.vcat{T<:AbstractDataFrame}(dfs::Vector{T})

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -108,4 +108,6 @@ module TestCat
 
     # Alignment
     @test isequal(vcat(dfda, dfd, dfa), vcat(dfda, dfda))
+
+    @test vcat(sub(DataFrame(A=1:3),2),DataFrame(A=4:5)) == DataFrame(A=[2,4,5])
 end

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -109,5 +109,6 @@ module TestCat
     # Alignment
     @test isequal(vcat(dfda, dfd, dfa), vcat(dfda, dfda))
 
+    # vcat should be able to concatenate different implementations of AbstractDataFrame (PR #944)
     @test vcat(sub(DataFrame(A=1:3),2),DataFrame(A=4:5)) == DataFrame(A=[2,4,5])
 end


### PR DESCRIPTION
collect doesn't recognize the common type if the arguments are of mixed types