### PR TITLE
ModelMatrix need to be able to align categorical variables

### DIFF
--- a/src/statsmodels/statsmodel.jl
+++ b/src/statsmodels/statsmodel.jl
@@ -79,7 +79,7 @@ function StatsBase.predict(mm::DataFrameRegressionModel, df::AbstractDataFrame)
     newTerms = remove_response(mm.mf.terms)
     # create new model frame/matrix
     mf = ModelFrame(newTerms, df)
-    newX = ModelMatrix(mf).m
+    newX = ModelMatrix(mf, mm.mf.df[1:0,:]).m
     yp = predict(mm, newX)
     out = DataArray(eltype(yp), size(df, 1))
     out[mf.msng] = yp

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -66,8 +66,7 @@ m2 = fit(DummyMod, f2, d)
 @test coeftable(m2).rownms == ["(Intercept)", "x1p - 6", "x1p - 7", "x1p - 8"]
 
 ## predict w/ new data missing levels
-## FAILS: mismatch between number of model matrix columns
-## @test predict(m2, d[2:4, :]) == predict(m2)[2:4]
+@test predict(m2, d[2:4, :]) == predict(m2)[2:4]
 
 
 ## Another dummy model type to test fall-through show method


### PR DESCRIPTION
Categorical variables are described by PooledDataArrays. This fix is needed for two reasons.

1. PooledDataArrays could be recoded with a different order, thus the design matrix will be wrong.
2. The rows for which to run predict might not span all factors, consider for instance running predict for a single row.

I uncommented a previously failing test.