### PR TITLE
Fix InexactError in groupby() due to too many levels

### DIFF
--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -90,7 +90,8 @@ function groupby{T}(d::AbstractDataFrame, cols::Vector{T})
     dv = PooledDataArray(d[cols[ncols]])
     # if there are NAs, add 1 to the refs to avoid underflows in x later
     dv_has_nas = (findfirst(dv.refs, 0) > 0 ? 1 : 0)
-    x = copy(dv.refs) .+ dv_has_nas
+    # use UInt32 instead of the PDA's integer size since the number of levels can be high
+    x = copy!(similar(dv.refs, UInt32), dv.refs) .+ dv_has_nas
     # also compute the number of groups, which is the product of the set lengths
     ngroups = length(dv.pool) + dv_has_nas
     # if there's more than 1 column, do roughly the same thing repeatedly

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -29,4 +29,9 @@ module TestGrouping
     h(df) = g(f(df))
 
     @test combine(map(h, gd)) == combine(map(g, ga))
+
+    # issue #960
+    x = pool(collect(1:20))
+    df = DataFrame(v1=x, v2=x)
+    groupby(df, [:v1, :v2])
 end


### PR DESCRIPTION
Using the storage size of the first PDA does not make sense, since it can have
very few levels, and yet its combination with other columns may produce a lot
of them. UInt32 will be enough for any reasonable number of levels.

Fixes https://github.com/JuliaStats/DataFrames.jl/issues/960.