### PR TITLE
Undo restriction of AbstractString to String

### DIFF
--- a/src/RDA.jl
+++ b/src/RDA.jl
@@ -207,7 +207,7 @@ type RDANativeIO{T<:IO} <: RDAIO # RDA native binary format IO stream wrapper (T
 end
 RDANativeIO{T <: IO}(io::T) = RDANativeIO{T}(io)
 
-function rdaio(io::IO, formatcode::String)
+function rdaio(io::IO, formatcode::AbstractString)
     if formatcode == "X" RDAXDRIO(io)
     elseif formatcode == "A" RDAASCIIIO(io)
     elseif formatcode == "B" RDANativeIO(io)
@@ -415,7 +415,7 @@ end
 
 read_rda(io::IO; kwoptions...) = read_rda(io, kwoptions)
 
-read_rda(fnm::String; kwoptions...) = gzopen(fnm) do io read_rda(io, kwoptions) end
+read_rda(fnm::AbstractString; kwoptions...) = gzopen(fnm) do io read_rda(io, kwoptions) end
 
 ##############################################################################
 ##

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -4,11 +4,11 @@
 #
 ##############################################################################
 
-function escapedprint(io::IO, x::Any, escapes::String)
+function escapedprint(io::IO, x::Any, escapes::AbstractString)
     print(io, x)
 end
 
-function escapedprint(io::IO, x::String, escapes::String)
+function escapedprint(io::IO, x::AbstractString, escapes::AbstractString)
     print_escaped(io, x, escapes)
 end
 
@@ -17,7 +17,7 @@ function printtable(io::IO,
                     header::Bool = true,
                     separator::Char = ',',
                     quotemark::Char = '"',
-                    nastring::String = "NA")
+                    nastring::AbstractString = "NA")
     n, p = size(df)
     etypes = eltypes(df)
     if header
@@ -61,7 +61,7 @@ function printtable(df::AbstractDataFrame;
                     header::Bool = true,
                     separator::Char = ',',
                     quotemark::Char = '"',
-                    nastring::String = "NA")
+                    nastring::AbstractString = "NA")
     printtable(STDOUT,
                df,
                header = header,
@@ -80,7 +80,7 @@ writetable(filename, df, [keyword options])
 
 ### Arguments
 
-* `filename::String` : the filename to be created
+* `filename::AbstractString` : the filename to be created
 * `df::AbstractDataFrame` : the AbstractDataFrame to be written
 
 ### Keyword Arguments
@@ -88,7 +88,7 @@ writetable(filename, df, [keyword options])
 * `separator::Char` -- The separator character that you would like to use. Defaults to the output of `getseparator(filename)`, which uses commas for files that end in `.csv`, tabs for files that end in `.tsv` and a single space for files that end in `.wsv`.
 * `quotemark::Char` -- The character used to delimit string fields. Defaults to `'"'`.
 * `header::Bool` -- Should the file contain a header that specifies the column names from `df`. Defaults to `true`.
-* `nastring::String` -- What to write in place of missing data. Defaults to `"NA"`.
+* `nastring::AbstractString` -- What to write in place of missing data. Defaults to `"NA"`.
 
 ### Result
 
@@ -104,12 +104,12 @@ writetable("output.dat", df, quotemark = '\', separator = ',')
 writetable("output.dat", df, header = false)
 ```
 """
-function writetable(filename::String,
+function writetable(filename::AbstractString,
                     df::AbstractDataFrame;
                     header::Bool = true,
                     separator::Char = getseparator(filename),
                     quotemark::Char = '"',
-                    nastring::String = "NA",
+                    nastring::AbstractString = "NA",
                     append::Bool = false)
 
     if endswith(filename, ".bz") || endswith(filename, ".bz2")
@@ -155,7 +155,7 @@ end
 #
 ##############################################################################
 
-function html_escape(cell::String)
+function html_escape(cell::AbstractString)
     cell = replace(cell, "&", "&amp;")
     cell = replace(cell, "<", "&lt;")
     cell = replace(cell, ">", "&gt;")

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -38,7 +38,7 @@ let
         ourshowcompact(io, x)
         return position(io)
     end
-    ourstrwidth(x::String) = strwidth(x) + 2 # -> Int
+    ourstrwidth(x::AbstractString) = strwidth(x) + 2 # -> Int
     myconv = VERSION < v"0.4-" ? convert : Base.unsafe_convert
     ourstrwidth(s::Symbol) =
         @compat Int(ccall(:u8_strwidth,
@@ -63,7 +63,7 @@ end
 #' ourshowcompact(STDOUT, "abc")
 #' ourshowcompact(STDOUT, 10000)
 ourshowcompact(io::IO, x::Any) = showcompact(io, x) # -> Void
-ourshowcompact(io::IO, x::String) = showcompact(io, x) # -> Void
+ourshowcompact(io::IO, x::AbstractString) = showcompact(io, x) # -> Void
 ourshowcompact(io::IO, x::Symbol) = print(io, x) # -> Void
 
 #' @description
@@ -85,7 +85,7 @@ ourshowcompact(io::IO, x::Symbol) = print(io, x) # -> Void
 #'        chunk of the AbstractDataFrame that would be rendered to IO. Can
 #'        be empty if the AbstractDataFrame would be printed without any
 #'        ellipses.
-#' @param rowlabel::String The label that will be used when rendered the
+#' @param rowlabel::AbstractString The label that will be used when rendered the
 #'        numeric ID's of each row. Typically, this will be set to "Row".
 #'
 #' @returns widths::Vector{Int} The maximum string widths required to render

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -776,7 +776,7 @@ end
 # TODO: Deprecate or change for being too inconsistent with other pool methods
 function pool!(df::DataFrame)
     for i in 1:size(df, 2)
-        if eltype(df[i]) <: String
+        if eltype(df[i]) <: AbstractString
             df[i] = pool(df[i])
         end
     end

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -9,7 +9,7 @@ if VERSION >= v"0.4.0-dev+757"
     push!(RESERVED_WORDS, "stagedfunction")
 end
 
-function identifier(s::String)
+function identifier(s::AbstractString)
     s = normalize_string(s)
     if !isidentifier(s)
         s = makeidentifier(s)
@@ -17,7 +17,7 @@ function identifier(s::String)
     @compat(Symbol(in(s, RESERVED_WORDS) ? "_"*s : s))
 end
 
-function makeidentifier(s::String)
+function makeidentifier(s::AbstractString)
     i = start(s)
     done(s, i) && return "x"
 

--- a/test/io.jl
+++ b/test/io.jl
@@ -145,7 +145,7 @@ module TestIO
 
     function normalize_eol!(df)
         for (name, col) in eachcol(df)
-            if eltype(col) <: String
+            if eltype(col) <: AbstractString
                 df[name] = map(s -> replace(s, "\r\n", "\n"), col)
             end
         end


### PR DESCRIPTION
Accidentally, I also changed `AbstractString` in https://github.com/JuliaStats/DataFrames.jl/pull/957 and it caused https://github.com/JuliaStats/DataFrames.jl/issues/963. This PR should fix this.