### PR TITLE
Stop using rep()

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,5 +4,5 @@ StatsBase 0.8.0
 GZip
 SortingAlgorithms
 Reexport
-Compat 0.7.17
+Compat 0.7.19
 Docile

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -248,8 +248,8 @@ end
 
 function crossjoin(df1::AbstractDataFrame, df2::AbstractDataFrame)
     r1, r2 = size(df1, 1), size(df2, 1)
-    cols = [[rep(c, 1, r2) for c in columns(df1)];
-            [rep(c, r1, 1) for c in columns(df2)]]
+    cols = [[Compat.repeat(c, inner=r2) for c in columns(df1)];
+            [Compat.repeat(c, outer=r1) for c in columns(df2)]]
     colindex = merge(index(df1), index(df2))
     DataFrame(cols, colindex)
 end

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -77,9 +77,9 @@ function stack(df::AbstractDataFrame, measure_vars::Vector{Int}, id_vars::Vector
     cnames = names(df)[id_vars]
     insert!(cnames, 1, :value)
     insert!(cnames, 1, :variable)
-    DataFrame(Any[rep(_names(df)[measure_vars], rep(nrow(df), N)),   # variable
-                  vcat([df[c] for c in measure_vars]...),           # value
-                  [rep(df[c], N) for c in id_vars]...],             # id_var columns
+    DataFrame(Any[Compat.repeat(_names(df)[measure_vars], inner=nrow(df)),   # variable
+                  vcat([df[c] for c in measure_vars]...),                    # value
+                  [Compat.repeat(df[c], outer=N) for c in id_vars]...],      # id_var columns
               cnames)
 end
 function stack(df::AbstractDataFrame, measure_vars::Int, id_vars::Int)

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -40,7 +40,9 @@ use column-based indexing with `sub`.
 ### Examples
 
 ```julia
-df = DataFrame(a = rep(1:4, 2), b = rep(2:-1:1, 4), c = randn(8))
+df = DataFrame(a = repeat([1, 2, 3, 4], outer=[2]),
+               b = repeat([2, 1], outer=[4]),
+               c = randn(8))
 sdf1 = sub(df, 1:6)
 sdf2 = sub(df, df[:a] .> 1)
 sdf3 = sub(df[[1,3]], df[:a] .> 1)  # row and column subsetting

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -2,7 +2,9 @@ module TestGrouping
     using Base.Test
     using DataFrames
 
-    df = DataFrame(a=rep(1:4, 2), b=rep(2:-1:1, 4), c=randn(8))
+    df = DataFrame(a = repeat([1, 2, 3, 4], outer=[2]),
+                   b = repeat([2, 1], outer=[4]),
+                   c = randn(8))
     #df[6, :a] = NA
     #df[7, :b] = NA
 


### PR DESCRIPTION
This function lives in DataArrays and is mostly redundant with
Base.repeat(). Use the latter where possible, or custom code
when not, so that we can deprecate rep().

Cf. https://github.com/JuliaStats/DataArrays.jl/pull/186.