### PR TITLE
Fix passing UTF8String to readtable's eltypes argument

### DIFF
--- a/src/dataframe/io.jl
+++ b/src/dataframe/io.jl
@@ -624,7 +624,7 @@ function builddf(rows::Integer,
                     continue
                 else
                     is_bool = false
-                    values = Array(String, rows)
+                    values = Array(Compat.UTF8String, rows)
                     i = 0
                     continue
                 end
@@ -632,7 +632,7 @@ function builddf(rows::Integer,
 
             # (4) Fallback to String
             values[i], wasparsed, missing[i] =
-              bytestotype(String,
+              bytestotype(Compat.UTF8String,
                           p.bytes,
                           left,
                           right,
@@ -835,14 +835,8 @@ function readtable(io::IO,
 
     if !isempty(eltypes)
         for j in 1:length(eltypes)
-            if !(eltypes[j] in [String, Bool, Float64, Int64])
-                msgio = IOBuffer()
-                @printf(msgio,
-                        "Invalid eltype '%s' encountered.\n",
-                        eltypes[j])
-                @printf(msgio,
-                        "Valid eltypes: String, Bool, Float64 or Int64")
-                error(bytestring(msgio))
+            if !(eltypes[j] in [Compat.UTF8String, Bool, Float64, Int64])
+                throw(ArgumentError("Invalid eltype $(eltypes[j]) encountered.\nValid eltypes: $(Compat.UTF8String), Bool, Float64 or Int64"))
             end
         end
     end
@@ -1189,7 +1183,7 @@ function filldf!(df::DataFrame,
 
             # NB: Assumes perfect type stability
             # Use subtypes here
-            if !(T in [Int, Float64, Bool, String])
+            if !(T in [Int, Float64, Bool, Compat.UTF8String])
                 error("Invalid eltype encountered")
             end
             c.data[i], wasparsed, c.na[i] =

--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -320,9 +320,9 @@ end
 
 function coefnames(mf::ModelFrame)
     if mf.terms.intercept
-        vnames = String["(Intercept)"]
+        vnames = Compat.UTF8String["(Intercept)"]
     else
-        vnames = String[]
+        vnames = Compat.UTF8String[]
     end
     # Need to only include active levels
     for term in mf.terms.terms

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -136,20 +136,12 @@ module TestDataFrame
     @test allna(df[:, 3])
 
 
-    if VERSION >= v"0.5.0-dev+3876"
-        df = DataFrame(DataType[Int, Float64, String],[:A, :B, :C], [false,false,true],100)
-    else
-        df = DataFrame(DataType[Int, Float64, UTF8String],[:A, :B, :C], [false,false,true],100)
-    end
+    df = DataFrame(DataType[Int, Float64, Compat.UTF8String],[:A, :B, :C], [false,false,true],100)
     @test size(df, 1) == 100
     @test size(df, 2) == 3
     @test typeof(df[:, 1]) == DataVector{Int}
     @test typeof(df[:, 2]) == DataVector{Float64}
-    if VERSION >= v"0.5.0-dev+3876"
-        @test typeof(df[:, 3]) == PooledDataVector{String,UInt32}
-    else
-        @test typeof(df[:, 3]) == PooledDataVector{UTF8String,UInt32}
-    end
+    @test typeof(df[:, 3]) == PooledDataVector{Compat.UTF8String,UInt32}
     @test allna(df[:, 1])
     @test allna(df[:, 2])
     @test allna(df[:, 3])

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,7 +1,6 @@
 module TestIO
     using Base.Test
     using DataFrames, Compat
-    import Compat.String
 
     #test_group("We can read various file types.")
 
@@ -237,7 +236,7 @@ module TestIO
     filename = "$data/factors/mixedvartypes.csv"
     df = readtable(filename, makefactors = true)
 
-    @test typeof(df[:factorvar]) == PooledDataArray{String,UInt32,1}
+    @test typeof(df[:factorvar]) == PooledDataArray{Compat.UTF8String,UInt32,1}
     @test typeof(df[:floatvar]) == DataArray{Float64,1}
 
     # Readtable shouldn't silently drop data when reading highly compressed gz.
@@ -247,7 +246,7 @@ module TestIO
     # Readtable type inference
     filename = "$data/typeinference/bool.csv"
     df = readtable(filename)
-    @test typeof(df[:Name]) == DataArray{String,1}
+    @test typeof(df[:Name]) == DataArray{Compat.UTF8String,1}
     @test typeof(df[:IsMale]) == DataArray{Bool,1}
     @test df[:IsMale][1] == true
     @test df[:IsMale][4] == false
@@ -258,11 +257,11 @@ module TestIO
     @test typeof(df[:IntlikeColumn]) == DataArray{Float64,1}
     @test typeof(df[:FloatColumn]) == DataArray{Float64,1}
     @test typeof(df[:BoolColumn]) == DataArray{Bool,1}
-    @test typeof(df[:StringColumn]) == DataArray{String,1}
+    @test typeof(df[:StringColumn]) == DataArray{Compat.UTF8String,1}
 
     filename = "$data/typeinference/mixedtypes.csv"
     df = readtable(filename)
-    @test typeof(df[:c1]) == DataArray{String,1}
+    @test typeof(df[:c1]) == DataArray{Compat.UTF8String,1}
     @test df[:c1][1] == "1"
     @test df[:c1][2] == "2.0"
     @test df[:c1][3] == "true"
@@ -270,7 +269,7 @@ module TestIO
     @test df[:c2][1] == 1.0
     @test df[:c2][2] == 3.0
     @test df[:c2][3] == 4.5
-    @test typeof(df[:c3]) == DataArray{String,1}
+    @test typeof(df[:c3]) == DataArray{Compat.UTF8String,1}
     @test df[:c3][1] == "0"
     @test df[:c3][2] == "1"
     @test df[:c3][3] == "f"
@@ -278,7 +277,7 @@ module TestIO
     @test df[:c4][1] == true
     @test df[:c4][2] == false
     @test df[:c4][3] == true
-    @test typeof(df[:c5]) == DataArray{String,1}
+    @test typeof(df[:c5]) == DataArray{Compat.UTF8String,1}
     @test df[:c5][1] == "False"
     @test df[:c5][2] == "true"
     @test df[:c5][3] == "true"
@@ -289,17 +288,17 @@ module TestIO
     df = readtable(filename)
     @test typeof(df[:n]) == DataArray{Int,1}
     @test df[:n][1] == 1
-    @test typeof(df[:s]) == DataArray{String,1}
+    @test typeof(df[:s]) == DataArray{Compat.UTF8String,1}
     @test df[:s][1] == "text"
     @test typeof(df[:f]) == DataArray{Float64,1}
     @test df[:f][1] == 2.3
     @test typeof(df[:b]) == DataArray{Bool,1}
     @test df[:b][1] == true
 
-    df = readtable(filename, eltypes = [Int64, String, Float64, Bool])
+    df = readtable(filename, eltypes = [Int64, Compat.UTF8String, Float64, Bool])
     @test typeof(df[:n]) == DataArray{Int64,1}
     @test df[:n][1] == 1
-    @test typeof(df[:s]) == DataArray{String,1}
+    @test typeof(df[:s]) == DataArray{Compat.UTF8String,1}
     @test df[:s][1] == "text"
     @test df[:s][4] == "text ole"
     @test typeof(df[:f]) == DataArray{Float64,1}
@@ -308,7 +307,7 @@ module TestIO
     @test df[:b][1] == true
     @test df[:b][2] == false
 
-    df = readtable(filename, eltypes = [Int64, String, Float64, String])
+    df = readtable(filename, eltypes = [Int64, Compat.UTF8String, Float64, Compat.UTF8String])
     @test typeof(df[:n]) == DataArray{Int64,1}
     @test df[:n][1] == 1.0
     @test isna(df[:s][3])
@@ -317,7 +316,7 @@ module TestIO
     @test df[:f][1] == 2.3
     @test df[:f][2] == 0.2
     @test df[:f][3] == 5.7
-    @test typeof(df[:b]) == DataArray{String,1}
+    @test typeof(df[:b]) == DataArray{Compat.UTF8String,1}
     @test df[:b][1] == "T"
     @test df[:b][2] == "FALSE"
 

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -2,7 +2,6 @@ module TestStatsModels
 using DataFrames
 using Base.Test
 using Compat
-import Compat.String
 
 # Tests for statsmodel.jl
 
@@ -74,7 +73,7 @@ m2 = fit(DummyMod, f2, d)
 
 ## Another dummy model type to test fall-through show method
 immutable DummyModTwo <: RegressionModel
-    msg::String
+    msg::Compat.UTF8String
 end
 
 StatsBase.fit(::Type{DummyModTwo}, ::Matrix, ::Vector) = DummyModTwo("hello!")

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -80,6 +80,7 @@ StatsBase.fit(::Type{DummyModTwo}, ::Matrix, ::Vector) = DummyModTwo("hello!")
 Base.show(io::IO, m::DummyModTwo) = println(io, m.msg)
 
 m2 = fit(DummyModTwo, f, d)
-@show m2
+io = IOBuffer()
+show(io, m2)
 
 end


### PR DESCRIPTION
This really needs to remain UTF8String on Julia 0.4.

Fixes https://github.com/JuliaStats/DataFrames.jl/issues/969.