### PR TITLE
Add strict checking of duplicates in names!

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -112,7 +112,8 @@ names!(df::AbstractDataFrame, vals)
 * `vals` : column names, normally a Vector{Symbol} the same length as
   the number of columns in `df`
 * `allow_duplicates` : if duplicate colum names are allowed; `false`
-  by default (duplicates not allowed)
+  by default (duplicates not allowed); if set to `true` non-conflicting
+  names are generated for duplicate column names
 
 **Result**
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -111,9 +111,9 @@ names!(df::AbstractDataFrame, vals)
 * `df` : the AbstractDataFrame
 * `vals` : column names, normally a Vector{Symbol} the same length as
   the number of columns in `df`
-* `allow_duplicates` : if duplicate colum names are allowed; `false`
-  by default (duplicates not allowed); if set to `true` non-conflicting
-  names are generated for duplicate column names
+* `allow_duplicates` : if `false` (the default), an error will be raised
+  if duplicate names are found; if `true`, duplicate names will be suffixed
+  with `_i` (`i` starting at 1 for the first duplicate).
 
 **Result**
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -111,6 +111,8 @@ names!(df::AbstractDataFrame, vals)
 * `df` : the AbstractDataFrame
 * `vals` : column names, normally a Vector{Symbol} the same length as
   the number of columns in `df`
+* `strict` : if names! should disallow duplicate colum names; `true`
+  by default (duplicates not allowed)
 
 **Result**
 
@@ -122,11 +124,13 @@ names!(df::AbstractDataFrame, vals)
 ```julia
 df = DataFrame(i = 1:10, x = rand(10), y = rand(["a", "b", "c"], 10))
 names!(df, [:a, :b, :c])
+names!(df, [:a, :b, :a])  # throws ArgumentError
+names!(df, [:a, :b, :a], strict=false)  # renames second :a to :a_1
 ```
 
 """
-function names!(df::AbstractDataFrame, vals)
-    names!(index(df), vals)
+function names!(df::AbstractDataFrame, vals; strict=true)
+    names!(index(df), vals; strict=strict)
     return df
 end
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -111,7 +111,7 @@ names!(df::AbstractDataFrame, vals)
 * `df` : the AbstractDataFrame
 * `vals` : column names, normally a Vector{Symbol} the same length as
   the number of columns in `df`
-* `strict` : if names! should disallow duplicate colum names; `true`
+* `allow_duplicates` : if duplicate colum names are allowed; `false`
   by default (duplicates not allowed)
 
 **Result**
@@ -125,12 +125,12 @@ names!(df::AbstractDataFrame, vals)
 df = DataFrame(i = 1:10, x = rand(10), y = rand(["a", "b", "c"], 10))
 names!(df, [:a, :b, :c])
 names!(df, [:a, :b, :a])  # throws ArgumentError
-names!(df, [:a, :b, :a], strict=false)  # renames second :a to :a_1
+names!(df, [:a, :b, :a], allow_duplicates=true)  # renames second :a to :a_1
 ```
 
 """
-function names!(df::AbstractDataFrame, vals; strict=true)
-    names!(index(df), vals; strict=strict)
+function names!(df::AbstractDataFrame, vals; allow_duplicates=false)
+    names!(index(df), vals; allow_duplicates=allow_duplicates)
     return df
 end
 

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -23,25 +23,13 @@ Base.deepcopy(x::Index) = copy(x) # all eltypes immutable
 Base.isequal(x::Index, y::Index) = isequal(x.lookup, y.lookup) && isequal(x.names, y.names)
 Base.(:(==))(x::Index, y::Index) = isequal(x, y)
 
-function names!(x::Index, nms::Vector{Symbol})
+function names!(x::Index, nms::Vector{Symbol}; strict=true)
     if length(nms) != length(x)
         throw(ArgumentError("Length of nms doesn't match length of x."))
     end
-    for i in 1:length(nms)
-        newname = nms[i]
-        oldname = x.names[i]
-
-        if newname != oldname
-            if x.lookup[oldname] >= i
-                delete!(x.lookup, oldname)
-            end
-            x.lookup[newname] = i
-            x.names[i] = newname
-        end
-    end
-    if length(x.names) != length(x.lookup)
-        throw(ArgumentError("Index corrupted by duplicate symbols in nms."))
-    end
+    newindex = Index(nms, strict=strict)
+    x.names = newindex.names
+    x.lookup = newindex.lookup
     return x
 end
 

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -9,8 +9,8 @@ type Index <: AbstractIndex   # an OrderedDict would be nice here...
     lookup::Dict{Symbol, Int}      # name => names array position
     names::Vector{Symbol}
 end
-function Index(names::Vector{Symbol})
-    u = make_unique(names)
+function Index(names::Vector{Symbol}; strict=false)
+    u = make_unique(names, strict=strict)
     lookup = Dict{Symbol, Int}(zip(u, 1:length(u)))
     Index(lookup, u)
 end

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -9,8 +9,8 @@ type Index <: AbstractIndex   # an OrderedDict would be nice here...
     lookup::Dict{Symbol, Int}      # name => names array position
     names::Vector{Symbol}
 end
-function Index(names::Vector{Symbol}; strict=false)
-    u = make_unique(names, strict=strict)
+function Index(names::Vector{Symbol}; allow_duplicates=true)
+    u = make_unique(names, allow_duplicates=allow_duplicates)
     lookup = Dict{Symbol, Int}(zip(u, 1:length(u)))
     Index(lookup, u)
 end
@@ -23,11 +23,11 @@ Base.deepcopy(x::Index) = copy(x) # all eltypes immutable
 Base.isequal(x::Index, y::Index) = isequal(x.lookup, y.lookup) && isequal(x.names, y.names)
 Base.(:(==))(x::Index, y::Index) = isequal(x, y)
 
-function names!(x::Index, nms::Vector{Symbol}; strict=true)
+function names!(x::Index, nms::Vector{Symbol}; allow_duplicates=false)
     if length(nms) != length(x)
         throw(ArgumentError("Length of nms doesn't match length of x."))
     end
-    newindex = Index(nms, strict=strict)
+    newindex = Index(nms, allow_duplicates=allow_duplicates)
     x.names = newindex.names
     x.lookup = newindex.lookup
     return x

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -58,9 +58,10 @@ function make_unique(names::Vector{Symbol}; allow_duplicates=true)
         in(name, seen) ? push!(dups, i) : push!(seen, name)
     end
     
-    if (!allow_duplicates) && length(dups) > 0
+    if !allow_duplicates && length(dups) > 0
         d = unique(names[dups])
-        msg = "Duplicate variable names: $d. Set allow_duplicates to true to fix it."
+        msg = """Duplicate variable names: $d.
+                 Pass allow_duplicates=true to make them unique using a suffix automatically."""
         throw(ArgumentError(msg))
     end
 

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -49,7 +49,7 @@ function makeidentifier(s::AbstractString)
     return takebuf_string(res)
 end
 
-function make_unique(names::Vector{Symbol})
+function make_unique(names::Vector{Symbol}; strict=false)
     seen = Set{Symbol}()
     names = copy(names)
     dups = Int[]
@@ -57,6 +57,12 @@ function make_unique(names::Vector{Symbol})
         name = names[i]
         in(name, seen) ? push!(dups, i) : push!(seen, name)
     end
+    
+    if strict && length(dups) > 0
+        d = unique(names[dups])
+        throw(ArgumentError("Duplicate variable names: $d"))
+    end
+
     for i in dups
         nm = names[i]
         k = 1

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -49,7 +49,7 @@ function makeidentifier(s::AbstractString)
     return takebuf_string(res)
 end
 
-function make_unique(names::Vector{Symbol}; strict=false)
+function make_unique(names::Vector{Symbol}; allow_duplicates=true)
     seen = Set{Symbol}()
     names = copy(names)
     dups = Int[]
@@ -58,9 +58,10 @@ function make_unique(names::Vector{Symbol}; strict=false)
         in(name, seen) ? push!(dups, i) : push!(seen, name)
     end
     
-    if strict && length(dups) > 0
+    if (!allow_duplicates) && length(dups) > 0
         d = unique(names[dups])
-        throw(ArgumentError("Duplicate variable names: $d"))
+        msg = "Duplicate variable names: $d. Set allow_duplicates to true to fix it."
+        throw(ArgumentError(msg))
     end
 
     for i in dups

--- a/test/index.jl
+++ b/test/index.jl
@@ -37,6 +37,8 @@ end
 
 @test names(i) == [:A,:B]
 @test names!(i, [:a,:b]) == Index([:a,:b])
+@test names!(i, [:a,:a], strict=false) == Index([:a,:a_1])
+@test_throws ArgumentError names!(i, [:a,:a]) 
 @test rename(i, @compat(Dict(:a=>:A, :b=>:B))) == Index([:A,:B])
 @test rename(i, :a, :A) == Index([:A,:b])
 @test rename(i, [:a], [:A]) == Index([:A,:b])

--- a/test/index.jl
+++ b/test/index.jl
@@ -36,7 +36,7 @@ for ind in inds
 end
 
 @test names(i) == [:A,:B]
-@test names!(i, [:a,:a], strict=false) == Index([:a,:a_1])
+@test names!(i, [:a,:a], allow_duplicates=true) == Index([:a,:a_1])
 @test_throws ArgumentError names!(i, [:a,:a]) 
 @test names!(i, [:a,:b]) == Index([:a,:b])
 @test rename(i, @compat(Dict(:a=>:A, :b=>:B))) == Index([:A,:B])

--- a/test/index.jl
+++ b/test/index.jl
@@ -36,9 +36,9 @@ for ind in inds
 end
 
 @test names(i) == [:A,:B]
-@test names!(i, [:a,:b]) == Index([:a,:b])
 @test names!(i, [:a,:a], strict=false) == Index([:a,:a_1])
 @test_throws ArgumentError names!(i, [:a,:a]) 
+@test names!(i, [:a,:b]) == Index([:a,:b])
 @test rename(i, @compat(Dict(:a=>:A, :b=>:B))) == Index([:A,:B])
 @test rename(i, :a, :A) == Index([:A,:b])
 @test rename(i, [:a], [:A]) == Index([:A,:b])

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -13,6 +13,8 @@ module TestUtils
     @test identifier("end") == :_end
 
     @test DataFrames.make_unique([:x, :x, :x_1, :x2]) == [:x, :x_2, :x_1, :x2]
+    @test_throws ArgumentError DataFrames.make_unique([:x, :x, :x_1, :x2], strict=true)
+    @test DataFrames.make_unique([:x, :x_1, :x2], strict=true) == [:x, :x_1, :x2]
 
     # Check that reserved words are up to date
     f = "$JULIA_HOME/../../src/julia-parser.scm"

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -13,8 +13,8 @@ module TestUtils
     @test identifier("end") == :_end
 
     @test DataFrames.make_unique([:x, :x, :x_1, :x2]) == [:x, :x_2, :x_1, :x2]
-    @test_throws ArgumentError DataFrames.make_unique([:x, :x, :x_1, :x2], strict=true)
-    @test DataFrames.make_unique([:x, :x_1, :x2], strict=true) == [:x, :x_1, :x2]
+    @test_throws ArgumentError DataFrames.make_unique([:x, :x, :x_1, :x2], allow_duplicates=false)
+    @test DataFrames.make_unique([:x, :x_1, :x2], allow_duplicates=false) == [:x, :x_1, :x2]
 
     # Check that reserved words are up to date
     f = "$JULIA_HOME/../../src/julia-parser.scm"


### PR DESCRIPTION
This fixes #972 by adding `strict` argument to `make_unique`, `Index` and `names!`.
If this fix PR is accepted `strict` can be added to `DataFrame` constructors to handle duplicate column names in similar way.