### PR TITLE
vcat should expand pooled columns when needed

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -722,6 +722,7 @@ function _colinfo{T<:AbstractDataFrame}(dfs::Vector{T})
                     coltyps[idx] = promote_type(oldtyp, ct)
                 end
                 nonnull_ct[idx] += !_isnullable(col)
+                similars[idx] = expandsimilarpool(similars[idx], col)
             else # new column
                 push!(colindex, cn)
                 push!(coltyps, ct)
@@ -740,6 +741,20 @@ function _colinfo{T<:AbstractDataFrame}(dfs::Vector{T})
 
     coltyps, colnams, similars
 end
+
+function expandsimilarpool{T,R<:Integer,N}(c1::PooledDataArray{T,R,N}, c2)
+    # expand pool to make room for all levels
+    pool = levels([levels(c1); levels(c2)])
+    # doesn't need any refs
+    norefs = DataArrays.RefArray(Array{DataArrays.DEFAULT_POOLED_REF_TYPE,N}())
+    # keep it compact (update the type of norefs)
+    compact(PooledDataArray(norefs, pool))
+end
+
+function expandsimilarpool(c1, c2)
+    c1
+end
+
 
 ##############################################################################
 ##

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -36,4 +36,8 @@ module TestGrouping
     x = pool(collect(1:20))
     df = DataFrame(v1=x, v2=x)
     groupby(df, [:v1, :v2])
+
+    a = DataFrame(x=pool(1:200))
+    b = DataFrame(x=pool(100:300))
+    vcat(a,b)
 end


### PR DESCRIPTION
`pool!` creates compact pooled dataframes that doesn't have room for more levels than needed.

When vcat-ing together such pooled dataframes the resulting pool might be need to be larger. This PR checks which levels that are needed prior to copying the data.

Canonical example

```
a = DataFrame(x=pool(1:200))
b = DataFrame(x=pool(100:300))
vcat(a,b)
```

A similar problem with DataArrays occurs for `vcat(pool(1:200), pool(100:300))` but that is not addressed by this PR.
