### PR TITLE
don't assume groups are non-empty

### DIFF
--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -217,7 +217,7 @@ function combine(ga::GroupApplied)
     gd, vals = ga.gd, ga.vals
     # Could be made shorter with a rep(x, lengths) function
     # See JuliaLang/julia#16443
-    idx = Vector{Int}(sum([size(val, 1) for val in vals]))
+    idx = Vector{Int}(sum(Int[size(val, 1) for val in vals]))
     j = 0
     for i in 1:length(vals)
         n = size(vals[i], 1)

--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -1,8 +1,10 @@
 function Base.show(io::IO, gd::GroupedDataFrame)
     N = length(gd)
     println(io, "$(typeof(gd))  $N groups with keys: $(gd.cols)")
-    println(io, "First Group:")
-    show(io, gd[1])
+    if N > 0
+        println(io, "First Group:")
+        show(io, gd[1])
+    end
     if N > 1
         print(io, "\n⋮\n")
         println(io, "Last Group:")

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -36,4 +36,6 @@ module TestGrouping
     x = pool(collect(1:20))
     df = DataFrame(v1=x, v2=x)
     groupby(df, [:v1, :v2])
+
+    by(e->1, DataFrame(x=[]), :x)
 end

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -37,5 +37,7 @@ module TestGrouping
     df = DataFrame(v1=x, v2=x)
     groupby(df, [:v1, :v2])
 
-    by(e->1, DataFrame(x=[]), :x)
+    df2 = by(e->1, DataFrame(x=Int64[]), :x)
+    @test size(df2) == (0,1)
+    @test sum(df2[:x]) == 0
 end


### PR DESCRIPTION
grouping on an empty data frame should not crash. `combine` can't create additional columns but returning an empty data frame is better than crashing.

Similarly, showing an GroupedDataFrame in the REPL should not assume that it's non-empty.