### PR TITLE
Fix InexactError in join() due to too many levels

### DIFF
--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -83,8 +83,13 @@ function DataArrays.PooledDataVecs(df1::AbstractDataFrame,
     # with a merged pool that "keys" the combination of column values.
     # The pools of the result don't really mean anything.
     dv1, dv2 = PooledDataVecs(df1[1], df2[1])
-    refs1 = dv1.refs .+ 1   # the + 1 handles NA's
-    refs2 = dv2.refs .+ 1
+    # use UInt32 instead of the minimum integer size chosen by PooledDataVecs
+    # since the number of levels can be high
+    refs1 = Vector{UInt32}(dv1.refs)
+    refs2 = Vector{UInt32}(dv2.refs)
+    # the + 1 handles NA's
+    refs1[:] += 1
+    refs2[:] += 1
     ngroups = length(dv1.pool) + 1
     for j = 2:ncol(df1)
         dv1, dv2 = PooledDataVecs(df1[j], df2[j])
@@ -94,7 +99,6 @@ function DataArrays.PooledDataVecs(df1::AbstractDataFrame,
         for i = 1:length(refs2)
             refs2[i] += (dv2.refs[i]) * ngroups
         end
-        # FIXME check for ngroups overflow, maybe recode refs to prevent it
         ngroups *= (length(dv1.pool) + 1)
     end
     # recode refs1 and refs2 to drop the unused column combinations and

--- a/test/join.jl
+++ b/test/join.jl
@@ -66,4 +66,12 @@ module TestJoin
 
     # Cross joins don't take keys
     @test_throws ArgumentError join(df1, df2, on = :A, kind = :cross)
+
+    # issue #960
+    df1 = DataFrame(A = 1:50,
+                    B = 1:50,
+                    C = 1)
+    pool!(df1, :A)
+    pool!(df1, :B)
+    join(df1, df1, on = [:A, :B], kind = :inner)
 end


### PR DESCRIPTION
PooledDataVecs() uses the smallest possible integer size, but
the DataFrames code stores higher references than that in the vector.
Always use UInt32, which will be enough for any reasonable number of
levels.

Maybe PooledDataVecs() should not compact its result by default
(which makes it type-unstable), but this should be considered as part
of a larger rework.

Fixes the second issue at https://github.com/JuliaStats/DataFrames.jl/issues/960.