### PR TITLE
Remove "stagedfunction" from reserved words

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 DataFrames.jl
 =============
 
-[![DataFrames](http://pkg.julialang.org/badges/DataFrames_0.3.svg)](http://pkg.julialang.org/?pkg=DataFrames&ver=0.3)
-[![DataFrames](http://pkg.julialang.org/badges/DataFrames_0.4.svg)](http://pkg.julialang.org/?pkg=DataFrames&ver=0.4)
+[![Julia 0.3 Status](http://pkg.julialang.org/badges/DataFrames_0.3.svg)](http://pkg.julialang.org/?pkg=DataFrames&ver=0.3)
+[![Julia 0.4 Status](http://pkg.julialang.org/badges/DataFrames_0.4.svg)](http://pkg.julialang.org/?pkg=DataFrames&ver=0.4)
+[![Julia 0.5 Status](http://pkg.julialang.org/badges/DataFrames_0.5.svg)](http://pkg.julialang.org/?pkg=DataFrames&ver=0.5)
 
 [![Coverage Status](https://coveralls.io/repos/JuliaStats/DataFrames.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaStats/DataFrames.jl?branch=master)
 [![Build Status](https://travis-ci.org/JuliaStats/DataFrames.jl.svg?branch=master)](https://travis-ci.org/JuliaStats/DataFrames.jl)

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -5,9 +5,6 @@ const RESERVED_WORDS = Set(["begin", "while", "if", "for", "try",
     "local", "global", "const", "abstract", "typealias", "type", "bitstype",
     "immutable", "ccall", "do", "module", "baremodule", "using", "import",
     "export", "importall", "end", "else", "elseif", "catch", "finally"])
-if VERSION >= v"0.4.0-dev+757"
-    push!(RESERVED_WORDS, "stagedfunction")
-end
 
 function identifier(s::AbstractString)
     s = normalize_string(s)


### PR DESCRIPTION
It only existed for a short period in the 0.4 development cycle. This
made the test fail on 0.5.