### PR TITLE
Bump dependency on DataArrays to v0.3.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
-DataArrays 0.2.15
+DataArrays 0.3.4
 StatsBase 0.8.0
 GZip
 SortingAlgorithms


### PR DESCRIPTION
A bug with repeat() on Julia 0.4 makes tests fail with previous versions.