### PR TITLE
Use vec to avoid indexing with a matrix

### DIFF
--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -301,7 +301,7 @@ function ModelMatrix(mf::ModelFrame)
     ff = trms.factors[:, fetrms]
     ## need to be cautious here to avoid evaluating cols for a factor with many levels
     ## if the factor doesn't occur in the fetrms
-    rows = Bool[x != 0 for x in sum(ff, 2)]
+    rows = Bool[x != 0 for x in vec(sum(ff, 2))]
     ff = ff[rows, :]
     cc = [cols(col) for col in columns(mf.df[:, rows])]
     for j in 1:size(ff,2)


### PR DESCRIPTION
This fixes an issue with a test in StatsBase wherein `Bool[x != 0 for x in sum(ff, 2)]` returns a vector on 0.4 but a matrix on 0.5. Using `vec` ensures that we always get a vector here, as desired.