### PR TITLE
Updates for Julia 0.5.

### DIFF
--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -15,8 +15,10 @@ using Reexport
 @reexport using DataArrays
 using GZip
 using SortingAlgorithms
-using Base: Sort, Order
 using Docile
+
+using Base: Sort, Order
+import Base: ==, |>
 
 @document
 

--- a/src/RDA.jl
+++ b/src/RDA.jl
@@ -139,7 +139,7 @@ end
 ##
 ##############################################################################
 
-LONG_VECTOR_SUPPORT = (WORD_SIZE > 32) # disable long vectors support on 32-bit machines
+LONG_VECTOR_SUPPORT = (Sys.WORD_SIZE > 32) # disable long vectors support on 32-bit machines
 
 if LONG_VECTOR_SUPPORT
     typealias RVecLength Int64
@@ -173,7 +173,7 @@ readfloatorNA(io::RDAXDRIO, n::RVecLength) =
 
 function readnchars(io::RDAXDRIO, n::Int32)  # a single character string
     readbytes!(io.sub, io.buf, n)
-    bytestring(pointer(io.buf), n)::String
+    unsafe_string(pointer(io.buf), n)
 end
 
 type RDAASCIIIO{T<:IO} <: RDAIO # RDA ASCII format IO stream wrapper

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -234,7 +234,7 @@ Base.ndims(::AbstractDataFrame) = 2
 ##############################################################################
 
 Base.similar(df::AbstractDataFrame, dims::Int) =
-    DataFrame([similar(x, dims) for x in columns(df)], copy(index(df)))
+    DataFrame(Any[similar(x, dims) for x in columns(df)], copy(index(df)))
 
 nas{T}(dv::AbstractArray{T}, dims::@compat(Union{Int, Tuple{Vararg{Int}}})) =   # TODO move to datavector.jl?
     DataArray(Array(T, dims), trues(dims))
@@ -260,7 +260,8 @@ function Base.isequal(df1::AbstractDataFrame, df2::AbstractDataFrame)
     return true
 end
 
-function Base.(:(==))(df1::AbstractDataFrame, df2::AbstractDataFrame)
+# Imported in DataFrames.jl for compatibility across Julia 0.4 and 0.5
+function (==)(df1::AbstractDataFrame, df2::AbstractDataFrame)
     size(df1, 2) == size(df2, 2) || return false
     isequal(index(df1), index(df2)) || return false
     eq = true

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -8,8 +8,14 @@ function escapedprint(io::IO, x::Any, escapes::AbstractString)
     print(io, x)
 end
 
-function escapedprint(io::IO, x::AbstractString, escapes::AbstractString)
-    print_escaped(io, x, escapes)
+@static if VERSION < v"0.5.0-"
+    function escapedprint(io::IO, x::AbstractString, escapes::AbstractString)
+        print_escaped(io, x, escapes)
+    end
+else
+    function escapedprint(io::IO, x::AbstractString, escapes::AbstractString)
+        escape_string(io, x, escapes)
+    end
 end
 
 function printtable(io::IO,
@@ -162,9 +168,7 @@ function html_escape(cell::AbstractString)
     return cell
 end
 
-function Base.writemime(io::IO,
-                        ::MIME"text/html",
-                        df::AbstractDataFrame)
+@compat function Base.show(io::IO, ::MIME"text/html", df::AbstractDataFrame)
     n = size(df, 1)
     cnames = _names(df)
     write(io, "<table class=\"data-frame\">")
@@ -202,14 +206,10 @@ end
 #
 ##############################################################################
 
-function Base.writemime(io::IO,
-                        ::MIME"text/csv",
-                        df::AbstractDataFrame)
+@compat function Base.show(io::IO, ::MIME"text/csv", df::AbstractDataFrame)
     printtable(io, df, true, ',')
 end
 
-function Base.writemime(io::IO,
-                        ::MIME"text/tab-separated-values",
-                        df::AbstractDataFrame)
+@compat function Base.show(io::IO, ::MIME"text/tab-separated-values", df::AbstractDataFrame)
     printtable(io, df, true, '\t')
 end

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -252,7 +252,7 @@ end
 
 function crossjoin(df1::AbstractDataFrame, df2::AbstractDataFrame)
     r1, r2 = size(df1, 1), size(df2, 1)
-    cols = [[Compat.repeat(c, inner=r2) for c in columns(df1)];
+    cols = Any[[Compat.repeat(c, inner=r2) for c in columns(df1)];
             [Compat.repeat(c, outer=r1) for c in columns(df2)]]
     colindex = merge(index(df1), index(df2))
     DataFrame(cols, colindex)

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -374,8 +374,8 @@ function aggregate{T<:Function}(gd::GroupedDataFrame, fs::Vector{T})
     headers = _makeheaders(fs, _setdiff(_names(gd), gd.cols))
     combine(map(x -> _aggregate(without(x, gd.cols), fs, headers), gd))
 end
-Base.(:|>)(gd::GroupedDataFrame, fs::Function) = aggregate(gd, fs)
-Base.(:|>){T<:Function}(gd::GroupedDataFrame, fs::Vector{T}) = aggregate(gd, fs)
+(|>)(gd::GroupedDataFrame, fs::Function) = aggregate(gd, fs)
+(|>){T<:Function}(gd::GroupedDataFrame, fs::Vector{T}) = aggregate(gd, fs)
 
 # Groups DataFrame by cols before applying aggregate
 function aggregate{S <: ColumnIndex, T <:Function}(d::AbstractDataFrame,

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -21,7 +21,8 @@ _names(x::Index) = x.names
 Base.copy(x::Index) = Index(copy(x.lookup), copy(x.names))
 Base.deepcopy(x::Index) = copy(x) # all eltypes immutable
 Base.isequal(x::Index, y::Index) = isequal(x.lookup, y.lookup) && isequal(x.names, y.names)
-Base.(:(==))(x::Index, y::Index) = isequal(x, y)
+# Imported in DataFrames.jl for compatibility across Julia 0.4 and 0.5
+(==)(x::Index, y::Index) = isequal(x, y)
 
 function names!(x::Index, nms::Vector{Symbol}; allow_duplicates=false)
     if length(nms) != length(x)

--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -301,7 +301,7 @@ function ModelMatrix(mf::ModelFrame)
     ff = trms.factors[:, fetrms]
     ## need to be cautious here to avoid evaluating cols for a factor with many levels
     ## if the factor doesn't occur in the fetrms
-    rows = Bool[x != 0 for x in sum(ff, 2)]
+    rows = vec(sum(ff, 2) .!= 0)
     ff = ff[rows, :]
     cc = [cols(col) for col in columns(mf.df[:, rows])]
     for j in 1:size(ff,2)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -285,7 +285,7 @@ module TestDataFrame
 
     # describe
     #suppress output and test that describe() does not throw
-    devnull = @unix? "/dev/null" : "nul"
+    devnull = is_unix() ? "/dev/null" : "nul"
     open(devnull, "w") do f
         @test nothing == describe(f, DataFrame(a=[1, 2], b=Any["3", NA]))
         @test nothing == describe(f, DataFrame(a=@data([1, 2]), b=@data(["3", NA])))


### PR DESCRIPTION
Import some operators instead of using `Base.(operator)` referencing for compatibility between 0.4 and 0.5

Make some array comprehensions Any such that they can be used in the `DataFrame` constructor

Adapt to shape preserving comprehensions

Some String stuff

cc: @ararslan 