### PR TITLE
Fix #1032

### DIFF
--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -409,10 +409,16 @@ end
 Drop the response term, `trms.eterms[1]` and the first row and column
 of `trms.factors` if `trms.response` is true.
 """
-dropresponse!(trms::Terms) = !trms.response ? trms :
-    Terms(trms.terms, trms.eterms[2 : end], trms.factors[2 : end, 2 : end],
-          trms.is_non_redundant[2 : end, 2 : end],
-          trms.order[2 : end], false, trms.intercept)
+function dropresponse!(trms::Terms)
+    if trms.response
+        ckeep = 2:size(trms.factors, 2)
+        rkeep = vec(any(trms.factors[:, ckeep], 2))
+        Terms(trms.terms, trms.eterms[rkeep], trms.factors[rkeep, ckeep],
+              trms.is_non_redundant[rkeep, ckeep], trms.order[ckeep], false, trms.intercept)
+    else
+        trms
+    end
+end
 
 
 """

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -369,6 +369,11 @@ module TestFormula
     mm = ModelMatrix(mf)
     @test mm.m[:, 2] == d[complete_cases(d), :x1m]
 
+    ## Same variable on left and right side
+    mf = ModelFrame(x1 ~ x1, df)
+    mm = ModelMatrix(mf)
+    mm.m == float(model_response(mf))
+
 ## Promote non-redundant categorical terms to full rank
 
 d = DataFrame(x = Compat.repeat([:a, :b], outer = 4),


### PR DESCRIPTION
Just have to check whether the response `eterm` is also present on the right side.