### PR TITLE
In coefnames, iterate over the terms after dropping, not the full set

### DIFF
--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -535,7 +535,7 @@ function coefnames(mf::ModelFrame)
 
     factors = terms.factors
 
-    for (i_term, term) in enumerate(mf.terms.terms)
+    for (i_term, term) in enumerate(terms.terms)
 
         ## names for columns for eval terms
         names = Vector{Compat.UTF8String}[]

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -500,6 +500,9 @@ mf = ModelFrame(n ~ 0 + x + x&y + x&z, d, contrasts=cs)
 # 4           1     0     0     0     1
 
 
-
+# Ensure that random effects terms are dropped from coefnames
+df = DataFrame(x = [1,2,3], y = [4,5,6])
+mf = ModelFrame(y ~ 1 + (1 | x), df)
+@test coefnames(mf) == ["(Intercept)"]
 
 end


### PR DESCRIPTION
This fixes and tests an issue that showed up in MixedModels, wherein `coefnames` was attempting to index into an empty array because it was iterating over the full model frame terms, not the terms after dropping the response and random effects.