### PR TITLE
Address tty_size deprecation warning

### DIFF
--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -178,7 +178,7 @@ end
         write(io, "<th>$column_name</th>")
     end
     write(io, "</tr>")
-    tty_rows, tty_cols = Base.tty_size()
+    tty_rows, tty_cols = Base.displaysize(io)
     mxrow = min(n,tty_rows)
     for row in 1:mxrow
         write(io, "<tr>")


### PR DESCRIPTION
Replacing call to tty_size with displaysize(io) to address deprecation warning for Julia 0.5.  This call is triggered when displaying a DataFrame in a Jupyter notebook via IJulia.