### PR TITLE
Avoid aliasing scalars on assignment

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -411,8 +411,8 @@ end
 function Base.setindex!{T <: ColumnIndex}(df::DataFrame,
                                   val::Any,
                                   col_inds::AbstractVector{T})
-    dv = upgrade_scalar(df, val)
     for col_ind in col_inds
+        dv = upgrade_scalar(df, val)
         insert_single_column!(df, dv, col_ind)
     end
     return df

--- a/test/mutation.jl
+++ b/test/mutation.jl
@@ -1,0 +1,9 @@
+module TestMutation
+    using Base.Test, DataFrames
+
+    # columns should not alias if scalar broadcasted
+    df = DataFrame(A=[0],B=[0])
+    df[1:end] = 0.0
+    df[1,:A] = 1.0
+    @test df[1,:B] === 0.0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,8 @@ my_tests = ["utils.jl",
             "duplicates.jl",
             "show.jl",
             "statsmodel.jl",
-            "contrasts.jl"]
+            "contrasts.jl",
+            "mutation.jl"]
 
 println("Running tests:")
 


### PR DESCRIPTION
This is a more conservative version of #1052. Fixes #1051.

cc @andreasnoack, cc @nalimilan, cc @ararslan 