### PR TITLE
Fill existing arrays with scalars

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -365,10 +365,13 @@ function Base.setindex!(df::DataFrame,
 end
 
 # df[SingleColumnIndex] = Single Item (EXPANDS TO NROW(DF) if NCOL(DF) > 0)
-function Base.setindex!(df::DataFrame,
-                v::Any,
-                col_ind::ColumnIndex)
-    insert_single_column!(df, upgrade_scalar(df, v), col_ind)
+function Base.setindex!(df::DataFrame, v, col_ind::ColumnIndex)
+    if haskey(index(df), col_ind)
+        fill!(df[col_ind], v)
+    else
+        insert_single_column!(df, upgrade_scalar(df, v), col_ind)
+    end
+    return df
 end
 
 # df[MultiColumnIndex] = DataFrame
@@ -397,7 +400,7 @@ function Base.setindex!{T <: ColumnIndex}(df::DataFrame,
                                   col_inds::AbstractVector{T})
     dv = upgrade_vector(v)
     for col_ind in col_inds
-        insert_single_column!(df, dv, col_ind)
+        df[col_ind] = dv
     end
     return df
 end
@@ -411,9 +414,8 @@ end
 function Base.setindex!{T <: ColumnIndex}(df::DataFrame,
                                   val::Any,
                                   col_inds::AbstractVector{T})
-    dv = upgrade_scalar(df, val)
     for col_ind in col_inds
-        insert_single_column!(df, dv, col_ind)
+        df[col_ind] = val
     end
     return df
 end

--- a/test/index.jl
+++ b/test/index.jl
@@ -56,4 +56,12 @@ for name in names(i)
   i2[name] # Issue #715
 end
 
+#= Aliasing & Mutation =#
+
+# columns should not alias if scalar broadcasted
+df = DataFrame(A=[0],B=[0])
+df[1:end] = 0.0
+df[1,:A] = 1.0
+@test df[1,:B] === 0
+
 end


### PR DESCRIPTION
Closes #1053 (replacing it). Fixes #1051. Closes (maybe?) #1054, pending possible further discussion.

This implements @nalimilan and @andreasnoack's idea of filling arrays with scalars instead of creating new ones.