### PR TITLE
Faster sparse model matrix construction

### DIFF
--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -370,8 +370,11 @@ function modelmat_cols{T<:AbstractFloatMatrix}(::Type{T}, v::PooledDataVector, c
     ## contrast matrix
     reindex = [findfirst(contrast.levels, l) for l in levels(v)]
     contrastmatrix = convert(T, contrast.matrix)
-    return contrastmatrix[reindex[v.refs], :]
+    return indexrows(contrastmatrix, reindex[v.refs])
 end
+
+indexrows(m::SparseMatrixCSC, ind::Vector{Int}) = m'[:, ind]'
+indexrows(m::AbstractMatrix, ind::Vector{Int}) = m[ind, :]
 
 """
     expandcols{T<:AbstractFloatMatrix}(trm::Vector{T})


### PR DESCRIPTION
Addresses slow row-wise `SparseMatrixCSC` indexing when building sparse model matrix columns by transposing the contrast matrix before reindexing column-wise, then transposing the result (rather than just reindexing row-wise).