### PR TITLE
Only sort duplicated columns once

### DIFF
--- a/src/dataframe/sort.jl
+++ b/src/dataframe/sort.jl
@@ -13,7 +13,10 @@ function Base.sort!(df::DataFrame, a::Base.Sort.Algorithm, o::Base.Sort.Ordering
     p = sortperm(df, a, o)
     pp = similar(p)
     c = columns(df)
-    uc = [!any(j->c[i] ≡ c[j], 1:i-1) for i=1:length(c)]
+
+    # Check that columns that shares the same underlying array are only permuted once PR#1072
+    uc = [!any(j->c[i] === c[j], 1:i-1) for i=1:length(c)]
+
     for col in c[uc]
         copy!(pp,p)
         Base.permute!!(col, pp)

--- a/src/dataframe/sort.jl
+++ b/src/dataframe/sort.jl
@@ -12,7 +12,9 @@ end
 function Base.sort!(df::DataFrame, a::Base.Sort.Algorithm, o::Base.Sort.Ordering)
     p = sortperm(df, a, o)
     pp = similar(p)
-    for col in columns(df)
+    c = columns(df)
+    uc = [!any(j->c[i] ≡ c[j], 1:i-1) for i=1:length(c)]
+    for col in c[uc]
         copy!(pp,p)
         Base.permute!!(col, pp)
     end

--- a/src/dataframe/sort.jl
+++ b/src/dataframe/sort.jl
@@ -15,7 +15,7 @@ function Base.sort!(df::DataFrame, a::Base.Sort.Algorithm, o::Base.Sort.Ordering
     c = columns(df)
 
     for (i,col) in enumerate(c)
-        # Check if this column has been sorted already. PR#1072
+        # Check if this column has been sorted already
         if any(j -> c[j]===col, 1:i-1)
             continue
         end

--- a/src/dataframe/sort.jl
+++ b/src/dataframe/sort.jl
@@ -14,10 +14,12 @@ function Base.sort!(df::DataFrame, a::Base.Sort.Algorithm, o::Base.Sort.Ordering
     pp = similar(p)
     c = columns(df)
 
-    # Check that columns that shares the same underlying array are only permuted once PR#1072
-    uc = [!any(j->c[i] === c[j], 1:i-1) for i=1:length(c)]
+    for (i,col) in enumerate(c)
+        # Check if this column has been sorted already. PR#1072
+        if any(j -> c[j]===col, 1:i-1)
+            continue
+        end
 
-    for col in c[uc]
         copy!(pp,p)
         Base.permute!!(col, pp)
     end

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -41,6 +41,7 @@ module TestSort
 
     @test df == ds
 
+    # Check that columns that shares the same underlying array are only permuted once PR#1072
     df = DataFrame(a=[2,1])
     df[:b] = df[:a]
     sort!(df, cols=:a)

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -41,5 +41,8 @@ module TestSort
 
     @test df == ds
 
-
+    df = DataFrame(a=[2,1])
+    df[:b] = df[:a]
+    sort!(df, cols=:a)
+    @test df == DataFrame(a=[1,2],b=[1,2])
 end


### PR DESCRIPTION
```
> df = DataFrame(a=[2,1]);
> df[:b] = df[:a];
> sort!(df, cols=:a)
2×2 DataFrames.DataFrame
│ Row │ a │ b │
├─────┼───┼───┤
│ 1   │ 2 │ 2 │
│ 2   │ 1 │ 1 │
```
The column `:a` is not sorted here. This happens because `:b` and `:a` refer to the same array which gets permuted twice. By skipping duplicated columns in the permutation we get the correct result.
```
2×2 DataFrames.DataFrame
│ Row │ a │ b │
├─────┼───┼───┤
│ 1   │ 1 │ 1 │
│ 2   │ 2 │ 2 │
```