### PR TITLE
Fix test failures on master

### DIFF
--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -304,12 +304,12 @@ colwise(sum, groupby(df, :a))
 ```
 
 """
-colwise(f::Function, d::AbstractDataFrame) = Any[collect(f(d[idx])) for idx in 1:size(d, 2)]
+colwise(f::Function, d::AbstractDataFrame) = Any[vcat(f(d[idx])) for idx in 1:size(d, 2)]
 colwise(f::Function, gd::GroupedDataFrame) = map(colwise(f), gd)
 colwise(f::Function) = x -> colwise(f, x)
 colwise(f) = x -> colwise(f, x)
 # apply several functions to each column in a DataFrame
-colwise{T<:Function}(fns::Vector{T}, d::AbstractDataFrame) = Any[collect(f(d[idx])) for f in fns, idx in 1:size(d, 2)][:]
+colwise{T<:Function}(fns::Vector{T}, d::AbstractDataFrame) = Any[vcat(f(d[idx])) for f in fns, idx in 1:size(d, 2)][:]
 colwise{T<:Function}(fns::Vector{T}, gd::GroupedDataFrame) = map(colwise(fns), gd)
 colwise{T<:Function}(fns::Vector{T}) = x -> colwise(fns, x)
 

--- a/test/data.jl
+++ b/test/data.jl
@@ -99,7 +99,7 @@ module TestData
     end
     @test isequal(res, sum(df7[:d1]))
 
-    @test aggregate(DataFrame(a=1),abs) == DataFrame(a_abs=1)
+    @test aggregate(DataFrame(a=1), identity) == DataFrame(a_identity=1)
 
     df8 = aggregate(df7[[1, 3]], sum)
     @test isequal(df8[1, :d1_sum], sum(df7[:d1]))


### PR DESCRIPTION
Use vcat() instead of collect() in colwise(), and identity() instead of abs(),
since the latter do not work with Nullable.

--------------

I introduced test failures when merging https://github.com/JuliaStats/DataFrames.jl/pull/939, as the fact that test passed when the PR was opened does not indicate that it still works today (even if there are no merge conflicts). We should probably close and reopen all PRs filed before the port before merging them.