### PR TITLE
Misc minor enhancements

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -79,13 +79,17 @@ abstract AbstractDataFrame
 ##
 ##############################################################################
 
-immutable Cols{T <: AbstractDataFrame}
+immutable Cols{T <: AbstractDataFrame} <: AbstractVector{Any}
     df::T
 end
 Base.start(::Cols) = 1
 Base.done(itr::Cols, st) = st > length(itr.df)
 Base.next(itr::Cols, st) = (itr.df[st], st + 1)
 Base.length(itr::Cols) = length(itr.df)
+Base.size(itr::Cols, ix) = ix==1 ? length(itr) : throw(ArgumentError("Incorrect dimension"))
+Base.size(itr::Cols) = (length(itr.df),)
+Base.linearindexing{T}(::Type{Cols{T}}) = Base.LinearFast()
+Base.getindex(itr::Cols, inds...) = getindex(itr.df, inds...)
 
 # N.B. where stored as a vector, 'columns(x) = x.vector' is a bit cheaper
 columns{T <: AbstractDataFrame}(df::T) = Cols{T}(df)

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -201,14 +201,7 @@ eltypes(df)
 ```
 
 """
-function eltypes(df::AbstractDataFrame)
-    ncols = size(df, 2)
-    res = Array(Type, ncols)
-    for j in 1:ncols
-        res[j] = eltype(df[j])
-    end
-    return res
-end
+eltypes(df::AbstractDataFrame) = map!(eltype, Vector{Type}(size(df,2)), columns(df))
 
 Base.size(df::AbstractDataFrame) = (nrow(df), ncol(df))
 function Base.size(df::AbstractDataFrame, i::Integer)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -78,25 +78,23 @@ function stack(df::AbstractDataFrame, measure_vars::Vector{Int}, id_vars::Vector
                   [Compat.repeat(df[c], outer=N) for c in id_vars]...],      # id_var columns
               cnames)
 end
-function stack(df::AbstractDataFrame, measure_vars::Int, id_vars::Int)
-    stack(df, [measure_vars], [id_vars])
+function stack(df::AbstractDataFrame, measure_var::Int, id_var::Int)
+    stack(df, [measure_var], [id_var])
 end
-function stack(df::AbstractDataFrame, measure_vars::Vector{Int}, id_vars::Int)
-    stack(df, measure_vars, [id_vars])
+function stack(df::AbstractDataFrame, measure_vars::Vector{Int}, id_var::Int)
+    stack(df, measure_vars, [id_var])
 end
-function stack(df::AbstractDataFrame, measure_vars::Int, id_vars::Vector{Int})
-    stackdf(df, [measure_vars], id_vars)
+function stack(df::AbstractDataFrame, measure_var::Int, id_vars::Vector{Int})
+    stackdf(df, [measure_var], id_vars)
 end
 stack(df::AbstractDataFrame, measure_vars, id_vars) =
     stack(df, index(df)[measure_vars], index(df)[id_vars])
-function stack(df::AbstractDataFrame, measure_vars)
+# no vars specified, by default select only numeric columns
+numeric_vars(df::AbstractDataFrame) = [T <: AbstractFloat || (T <: Nullable && eltype(T) <: AbstractFloat)
+                                       for T in eltypes(df)]
+function stack(df::AbstractDataFrame, measure_vars = numeric_vars(df))
     mv_inds = index(df)[measure_vars]
     stack(df, mv_inds, _setdiff(1:ncol(df), mv_inds))
-end
-function stack(df::AbstractDataFrame)
-    idx = find([T <: AbstractFloat || (T <: Nullable && eltype(T) <: AbstractFloat)
-                for T in eltypes(df)])
-    stack(df, idx)
 end
 
 """
@@ -221,7 +219,7 @@ function unstack(df::AbstractDataFrame, colkey::Int, value::Int)
         i = rowkey[k]
         if i > 0 && j > 0
             if nowarning && !isnull(df2[j][i])
-                warn("Duplicate entries in unstack.")
+                warn("Duplicate entries in unstack at row $k.")
                 nowarning = false
             end
             df2[j][i]  = valuecol[k]
@@ -251,7 +249,7 @@ NOTE: Not exported.
 ### Constructor
 
 ```julia
-RepeatedVector(d::AbstractVector...)
+StackedVector(d::AbstractVector...)
 ```
 
 ### Arguments
@@ -432,26 +430,21 @@ function stackdf(df::AbstractDataFrame, measure_vars::Vector{Int}, id_vars::Vect
                   [RepeatedVector(df[:,c], 1, N) for c in id_vars]...],     # id_var columns
               cnames)
 end
-function stackdf(df::AbstractDataFrame, measure_vars::Int, id_vars::Int)
-    stackdf(df, [measure_vars], [id_vars])
+function stackdf(df::AbstractDataFrame, measure_var::Int, id_var::Int)
+    stackdf(df, [measure_var], [id_var])
 end
-function stackdf(df::AbstractDataFrame, measure_vars, id_vars::Int)
-    stackdf(df, measure_vars, [id_vars])
+function stackdf(df::AbstractDataFrame, measure_vars, id_var::Int)
+    stackdf(df, measure_vars, [id_var])
 end
-function stackdf(df::AbstractDataFrame, measure_vars::Int, id_vars)
-    stackdf(df, [measure_vars], id_vars)
+function stackdf(df::AbstractDataFrame, measure_var::Int, id_vars)
+    stackdf(df, [measure_var], id_vars)
 end
 function stackdf(df::AbstractDataFrame, measure_vars, id_vars)
     stackdf(df, index(df)[measure_vars], index(df)[id_vars])
 end
-function stackdf(df::AbstractDataFrame, measure_vars)
+function stackdf(df::AbstractDataFrame, measure_vars = numeric_vars(df))
     m_inds = index(df)[measure_vars]
     stackdf(df, m_inds, _setdiff(1:ncol(df), m_inds))
-end
-function stackdf(df::AbstractDataFrame)
-    idx = find([T <: AbstractFloat || (T <: Nullable && eltype(T) <: AbstractFloat)
-                for T in eltypes(df)])
-    stackdf(df, idx)
 end
 
 """

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -70,14 +70,13 @@ groupby(cols)
 
 ### Arguments
 
-* `d` : an AbstractDataFrame
-* `cols` : an
-
-If `d` is not provided, a curried version of groupby is given.
+* `d` : an AbstractDataFrame to split (optional, see [Returns](#returns))
+* `cols` : data frame columns to group by
 
 ### Returns
 
 * `::GroupedDataFrame` : a grouped view into `d`
+* `::Function`: a function `x -> groupby(x, cols)` (if `d` is not specified)
 
 ### Details
 

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -38,17 +38,39 @@ module TestCat
     # Assignment of rows
     df[1, :] = df[1, :]
     df[1:2, :] = df[1:2, :]
+    df[[true,false,false,true], :] = df[2:3, :]
 
-    # Broadcasting assignment of rows
+    # Scalar broadcasting assignment of rows
     df[1, :] = 1
+    df[1:2, :] = 1
+    df[[true,false,false,true], :] = 3
+
+    # Vector broadcasting assignment of rows
+    df[1:2, :] = [2,3]
+    df[[true,false,false,true], :] = [2,3]
 
     # Assignment of columns
     df[1] = zeros(4)
+    df[:, 2] = ones(4)
 
     # Broadcasting assignment of columns
     df[:, 1] = 1
     df[1] = 3
     df[:x3] = 2
+
+    # assignment of subframes
+    df[1, 1:2] = df[2, 2:3]
+    df[1:2, 1:2] = df[2:3, 2:3]
+    df[[true,false,false,true], 2:3] = df[1:2,1:2]
+
+    # scalar broadcasting assignment of subframes
+    df[1, 1:2] = 3
+    df[1:2, 1:2] = 3
+    df[[true,false,false,true], 2:3] = 3
+
+    # vector broadcasting assignment of subframes
+    df[1:2, 1:2] = [3,2]
+    df[[true,false,false,true], 2:3] = [2,3]
 
     vcat([])
     vcat(null_df)

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -32,6 +32,16 @@ module TestGrouping
 
     @test isequal(combine(map(h, gd)), combine(map(g, ga)))
 
+    # testing pool overflow
+    df2 = DataFrame(v1 = categorical(collect(1:1000)), v2 = categorical(fill(1, 1000)))
+    @test groupby(df2, [:v1, :v2]).starts == collect(1:1000)
+    @test groupby(df2, [:v2, :v1]).starts == collect(1:1000)
+
+    # grouping empty frame
+    @test groupby(DataFrame(A=Int[]), :A).starts == Int[]
+    # grouping single row
+    @test groupby(DataFrame(A=Int[1]), :A).starts == Int[1]
+
     # issue #960
     x = CategoricalArray(collect(1:20))
     df = DataFrame(v1=x, v2=x)

--- a/test/join.jl
+++ b/test/join.jl
@@ -67,6 +67,30 @@ module TestJoin
     # Cross joins don't take keys
     @test_throws ArgumentError join(df1, df2, on = :A, kind = :cross)
 
+    # test empty inputs
+    simple_df(len::Int, col=:A) = (df = DataFrame(); df[col]=collect(1:len); df)
+    @test isequal(join(simple_df(0), simple_df(0), on = :A, kind = :left),  simple_df(0))
+    @test isequal(join(simple_df(2), simple_df(0), on = :A, kind = :left),  simple_df(2))
+    @test isequal(join(simple_df(0), simple_df(2), on = :A, kind = :left),  simple_df(0))
+    @test isequal(join(simple_df(0), simple_df(0), on = :A, kind = :right), simple_df(0))
+    @test isequal(join(simple_df(0), simple_df(2), on = :A, kind = :right), simple_df(2))
+    @test isequal(join(simple_df(2), simple_df(0), on = :A, kind = :right), simple_df(0))
+    @test isequal(join(simple_df(0), simple_df(0), on = :A, kind = :inner), simple_df(0))
+    @test isequal(join(simple_df(0), simple_df(2), on = :A, kind = :inner), simple_df(0))
+    @test isequal(join(simple_df(2), simple_df(0), on = :A, kind = :inner), simple_df(0))
+    @test isequal(join(simple_df(0), simple_df(0), on = :A, kind = :outer), simple_df(0))
+    @test isequal(join(simple_df(0), simple_df(2), on = :A, kind = :outer), simple_df(2))
+    @test isequal(join(simple_df(2), simple_df(0), on = :A, kind = :outer), simple_df(2))
+    @test isequal(join(simple_df(0), simple_df(0), on = :A, kind = :semi),  simple_df(0))
+    @test isequal(join(simple_df(2), simple_df(0), on = :A, kind = :semi),  simple_df(0))
+    @test isequal(join(simple_df(0), simple_df(2), on = :A, kind = :semi),  simple_df(0))
+    @test isequal(join(simple_df(0), simple_df(0), on = :A, kind = :anti),  simple_df(0))
+    @test isequal(join(simple_df(2), simple_df(0), on = :A, kind = :anti),  simple_df(2))
+    @test isequal(join(simple_df(0), simple_df(2), on = :A, kind = :anti),  simple_df(0))
+    @test isequal(join(simple_df(0), simple_df(0, :B), kind = :cross), DataFrame(A=Int[], B=Int[]))
+    @test isequal(join(simple_df(0), simple_df(2, :B), kind = :cross), DataFrame(A=Int[], B=Int[]))
+    @test isequal(join(simple_df(2), simple_df(0, :B), kind = :cross), DataFrame(A=Int[], B=Int[]))
+
     # issue #960
     df1 = DataFrame(A = 1:50,
                     B = 1:50,


### PR DESCRIPTION
Several changes that looked too small and innocent for a separate PR:
  * more tests for corner-case joins/groupings/assignments
  * implement `AbstractVector` interface for `Cols` (mostly required to allow `map!(..., columns(df))` for `SubDataFrame`)
  * some optimizations for `GroupedDataFrame` (avoiding array reallocation, improving type inference)