### PR TITLE
limit attribute of IOContext is used for html generation

### DIFF
--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -180,7 +180,7 @@ end
     haslimit = get(io, :limit, true)
     n = size(df, 1)
     if haslimit
-        tty_rows, tty_cols = displaysize(io)
+        tty_rows, tty_cols = _displaysize(io)
         mxrow = min(n,tty_rows)
     else
         mxrow = n

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -169,7 +169,6 @@ function html_escape(cell::AbstractString)
 end
 
 @compat function Base.show(io::IO, ::MIME"text/html", df::AbstractDataFrame)
-    n = size(df, 1)
     cnames = _names(df)
     write(io, "<table class=\"data-frame\">")
     write(io, "<tr>")
@@ -178,8 +177,14 @@ end
         write(io, "<th>$column_name</th>")
     end
     write(io, "</tr>")
-    tty_rows, tty_cols = _displaysize(io)
-    mxrow = min(n,tty_rows)
+    haslimit = get(io, :limit, true)
+    n = size(df, 1)
+    if haslimit
+        tty_rows, tty_cols = displaysize(io)
+        mxrow = min(n,tty_rows)
+    else
+        mxrow = n
+    end
     for row in 1:mxrow
         write(io, "<tr>")
         write(io, "<th>$row</th>")

--- a/test/io.jl
+++ b/test/io.jl
@@ -520,11 +520,11 @@ module TestIO
     # test limit attribute of IOContext is used
     df = DataFrame(a=collect(1:1000))
     ioc = IOContext(IOBuffer(), displaysize=(10, 10), limit=false)
-    show(ioc, MIME{Symbol("text/html")}(), df)
-    @test ioc.io |> takebuf_string |> length > 10000
+    show(ioc, "text/html", df)
+    @test length(takebuf_string(ioc.io)) > 10000
 
     io = IOBuffer()
-    show(io, MIME{Symbol("text/html")}(), df)
-    @test io |> takebuf_string |> length < 10000
+    show(io, "text/html", df)
+    @test length(takebuf_string(io)) < 10000
 
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -516,4 +516,15 @@ module TestIO
     show(io, "text/html", df)
     str = takebuf_string(io)
     @test str == "<table class=\"data-frame\"><tr><th></th><th>Fish</th><th>Mass</th></tr><tr><th>1</th><td>Suzy</td><td>1.5</td></tr><tr><th>2</th><td>Amir</td><td>#NULL</td></tr></table>"
+
+    # test limit attribute of IOContext is used
+    df = DataFrame(a=collect(1:1000))
+    ioc = IOContext(IOBuffer(), displaysize=(10, 10), limit=false)
+    show(ioc, MIME{Symbol("text/html")}(), df)
+    @test ioc.io |> takebuf_string |> length > 10000
+
+    io = IOBuffer()
+    show(io, MIME{Symbol("text/html")}(), df)
+    @test io |> takebuf_string |> length < 10000
+
 end


### PR DESCRIPTION
 See #1098