### PR TITLE
Loosen constructor for a DataFrame

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -104,7 +104,7 @@ end
 
 function DataFrame(columns::AbstractVector,
                    cnames::AbstractVector{Symbol} = gennames(length(columns)))
-    return DataFrame(convert(Vector{Any}, columns), Index(cnames))
+    return DataFrame(convert(Vector{Any}, columns), Index(convert(Vector{Symbol}, cnames)))
 end
 
 

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -102,8 +102,8 @@ function DataFrame(; kwargs...)
     return result
 end
 
-function DataFrame{T}(columns::Vector{T},
-                   cnames::Vector{Symbol} = gennames(length(columns)))
+function DataFrame(columns::AbstractVector,
+                   cnames::AbstractVector{Symbol} = gennames(length(columns)))
     return DataFrame(convert(Vector{Any}, columns), Index(cnames))
 end
 

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -102,9 +102,9 @@ function DataFrame(; kwargs...)
     return result
 end
 
-function DataFrame(columns::Vector{Any},
+function DataFrame{T}(columns::Vector{T},
                    cnames::Vector{Symbol} = gennames(length(columns)))
-    return DataFrame(columns, Index(cnames))
+    return DataFrame(convert(Vector{Any}, columns), Index(cnames))
 end
 
 

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -185,7 +185,7 @@ module TestDataFrame
     @test typeof(df[:,:a]) == NullableVector{Int}
     @test typeof(df[:,:b]) == NullableVector{Char}
 
-    @test DataFrame([[1,2,3], [2.5,4.5,6.5]], [:A, :B]) == DataFrame(A = [1,2,3], B = [2.5,4.5,6.5])
+    @test DataFrame(NullableArray[[1,2,3],[2.5,4.5,6.5]], [:A, :B]) == DataFrame(A = [1,2,3], B = [2.5,4.5,6.5])
 
     # This assignment was missing before
     df = DataFrame(Column = [:A])

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -185,7 +185,7 @@ module TestDataFrame
     @test typeof(df[:,:a]) == NullableVector{Int}
     @test typeof(df[:,:b]) == NullableVector{Char}
 
-    @test DataFrame([[1,2,3], [2.5,4.5,6.5]], [:A, :B]) = DataFrame(A = [1,2,3], B = [2.5,4.5,6.5])
+    @test DataFrame([[1,2,3], [2.5,4.5,6.5]], [:A, :B]) == DataFrame(A = [1,2,3], B = [2.5,4.5,6.5])
 
     # This assignment was missing before
     df = DataFrame(Column = [:A])

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -185,6 +185,7 @@ module TestDataFrame
     @test typeof(df[:,:a]) == NullableVector{Int}
     @test typeof(df[:,:b]) == NullableVector{Char}
 
+    @test DataFrame([[1,2,3], [2.5,4.5,6.5]], [:A, :B]) = DataFrame(A = [1,2,3], B = [2.5,4.5,6.5])
 
     # This assignment was missing before
     df = DataFrame(Column = [:A])


### PR DESCRIPTION
It seems to be a little more difficult than it should be to pass a container of columns to the `DataFrame`'s constructor. This change lets you, e.g.

```julia
DataFrame([[1,2,3]], [:a])
```

Before this would complain because `[[1,2,3]]` is of type `Vector{Vector{Int}}` which is not a subtype of (concrete) type `Vector{Any}` (type parameters aren't convariant). This will automatically loosen the type parameter for the column container, if necessary.