### PR TITLE
Juno Display

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,4 +6,4 @@ SortingAlgorithms
 Reexport
 Compat 0.8.4
 FileIO 0.1.2
-Juno
+Juno 0.2.4

--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ SortingAlgorithms
 Reexport
 Compat 0.8.4
 FileIO 0.1.2
+Juno

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -581,7 +581,7 @@ end
 showcols(df::AbstractDataFrame) = showcols(STDOUT, df) # -> Void
 
 using Juno
-import Juno: Inline, Tree, Table, Row, strong
+import Juno: Inline, LazyTree, Table, Row, strong
 
 const SIZE = 25
 
@@ -591,6 +591,6 @@ const SIZE = 25
   header = map(x->strong(string(x)), names(frame)[1:width]')
   body = hcat([frame[1:height,i] for i = 1:width]...)
   view = Table(vcat(header, body))
-  Tree(Row(typeof(frame), text" ", Juno.dims(size(frame)...)),
-       [view])
+  LazyTree(Row(typeof(frame), text" ", Juno.dims(size(frame)...)),
+           () -> [view])
 end

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -581,14 +581,14 @@ end
 showcols(df::AbstractDataFrame) = showcols(STDOUT, df) # -> Void
 
 using Juno
-using Juno: Inline, LazyTree, Table, Row, strong, undefs
+using Juno: Inline, LazyTree, Table, Row, strong
 
 const SIZE = 25
 
 function tomat(df::AbstractDataFrame)
     res = Array{Any}(size(df))
     for (j, col) in enumerate(columns(df)), i = 1:length(col)
-      isassigned(col, i) && (res[i, j] = col[i])
+        isassigned(col, i) && (res[i, j] = col[i])
     end
     return res
 end
@@ -597,7 +597,7 @@ end
     width = min(size(df, 2), SIZE)
     height = min(size(df, 1), SIZE)
     header = map(x->strong(string(x)), names(df)[1:width]')
-    body = undefs(tomat(df))[1:height, 1:width]
+    body = Juno.undefs(tomat(df))[1:height, 1:width]
     view = Table(vcat(header, body))
     LazyTree(Row(typeof(df), text" ", Juno.dims(size(df)...)),
              () -> [view])

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -589,7 +589,7 @@ const SIZE = 25
     width = min(size(frame, 2), SIZE)
     height = min(size(frame, 1), SIZE)
     header = map(x->strong(string(x)), names(frame)[1:width]')
-    body = hcat([frame[1:height,i] for i = 1:width]...)
+    body = Array(frame[1:height, 1:width])
     view = Table(vcat(header, body))
     LazyTree(Row(typeof(frame), text" ", Juno.dims(size(frame)...)),
              () -> [view])

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -586,11 +586,11 @@ import Juno: Inline, LazyTree, Table, Row, strong
 const SIZE = 25
 
 @render Inline frame::AbstractDataFrame begin
-  width = min(size(frame, 2), SIZE)
-  height = min(size(frame, 1), SIZE)
-  header = map(x->strong(string(x)), names(frame)[1:width]')
-  body = hcat([frame[1:height,i] for i = 1:width]...)
-  view = Table(vcat(header, body))
-  LazyTree(Row(typeof(frame), text" ", Juno.dims(size(frame)...)),
-           () -> [view])
+    width = min(size(frame, 2), SIZE)
+    height = min(size(frame, 1), SIZE)
+    header = map(x->strong(string(x)), names(frame)[1:width]')
+    body = hcat([frame[1:height,i] for i = 1:width]...)
+    view = Table(vcat(header, body))
+    LazyTree(Row(typeof(frame), text" ", Juno.dims(size(frame)...)),
+             () -> [view])
 end

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -581,16 +581,16 @@ end
 showcols(df::AbstractDataFrame) = showcols(STDOUT, df) # -> Void
 
 using Juno
-import Juno: Inline, LazyTree, Table, Row, strong
+using Juno: Inline, LazyTree, Table, Row, strong
 
 const SIZE = 25
 
-@render Inline frame::AbstractDataFrame begin
-    width = min(size(frame, 2), SIZE)
-    height = min(size(frame, 1), SIZE)
-    header = map(x->strong(string(x)), names(frame)[1:width]')
-    body = Array(frame[1:height, 1:width])
+@render Inline df::AbstractDataFrame begin
+    width = min(size(df, 2), SIZE)
+    height = min(size(df, 1), SIZE)
+    header = map(x->strong(string(x)), names(df)[1:width]')
+    body = Array(df[1:height, 1:width])
     view = Table(vcat(header, body))
-    LazyTree(Row(typeof(frame), text" ", Juno.dims(size(frame)...)),
+    LazyTree(Row(typeof(df), text" ", Juno.dims(size(df)...)),
              () -> [view])
 end

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -585,7 +585,7 @@ using Juno: Inline, LazyTree, Table, Row, strong
 
 const SIZE = 25
 
-function tomat(df::AbstractDataFrame)
+function to_matrix(df::AbstractDataFrame)
     res = Array{Any}(size(df))
     for (j, col) in enumerate(columns(df)), i = 1:length(col)
         isassigned(col, i) && (res[i, j] = col[i])
@@ -597,7 +597,7 @@ end
     width = min(size(df, 2), SIZE)
     height = min(size(df, 1), SIZE)
     header = map(x->strong(string(x)), names(df)[1:width]')
-    body = Juno.undefs(tomat(df))[1:height, 1:width]
+    body = Juno.undefs(to_matrix(df))[1:height, 1:width]
     view = Table(vcat(header, body))
     LazyTree(Row(typeof(df), text" ", Juno.dims(size(df)...)),
              () -> [view])

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -581,15 +581,23 @@ end
 showcols(df::AbstractDataFrame) = showcols(STDOUT, df) # -> Void
 
 using Juno
-using Juno: Inline, LazyTree, Table, Row, strong
+using Juno: Inline, LazyTree, Table, Row, strong, undefs
 
 const SIZE = 25
+
+function tomat(df::AbstractDataFrame)
+    res = Array{Any}(size(df))
+    for (j, col) in enumerate(columns(df)), i = 1:length(col)
+      isassigned(col, i) && (res[i, j] = col[i])
+    end
+    return res
+end
 
 @render Inline df::AbstractDataFrame begin
     width = min(size(df, 2), SIZE)
     height = min(size(df, 1), SIZE)
     header = map(x->strong(string(x)), names(df)[1:width]')
-    body = Array(df[1:height, 1:width])
+    body = undefs(tomat(df))[1:height, 1:width]
     view = Table(vcat(header, body))
     LazyTree(Row(typeof(df), text" ", Juno.dims(size(df)...)),
              () -> [view])

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -579,3 +579,18 @@ function showcols(io::IO, df::AbstractDataFrame) # -> Void
 end
 
 showcols(df::AbstractDataFrame) = showcols(STDOUT, df) # -> Void
+
+using Juno
+import Juno: Inline, Tree, Table, Row, strong
+
+const SIZE = 25
+
+@render Inline frame::AbstractDataFrame begin
+  width = min(size(frame, 2), SIZE)
+  height = min(size(frame, 1), SIZE)
+  header = map(x->strong(string(x)), names(frame)[1:width]')
+  body = hcat([frame[1:height,i] for i = 1:width]...)
+  view = Table(vcat(header, body))
+  Tree(Row(typeof(frame), text" ", Juno.dims(size(frame)...)),
+       [view])
+end

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -593,7 +593,7 @@ function to_matrix(df::AbstractDataFrame)
     return res
 end
 
-@render Inline df::AbstractDataFrame begin
+function _render(df::AbstractDataFrame)
     width = min(size(df, 2), SIZE)
     height = min(size(df, 1), SIZE)
     header = map(x->strong(string(x)), names(df)[1:width]')
@@ -602,3 +602,5 @@ end
     LazyTree(Row(typeof(df), text" ", Juno.dims(size(df)...)),
              () -> [view])
 end
+
+@render Inline df::AbstractDataFrame _render(df)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -2,3 +2,4 @@ Compat 0.9.0
 DataStructures
 RDatasets # can be removed when deprecated.jl doesn't test read_rda anymore
 RData
+Atom

--- a/test/show.jl
+++ b/test/show.jl
@@ -17,8 +17,8 @@ module TestShow
     showall(io, subdf, true)
 
     if VERSION > v"0.5-"
-      using Atom, Juno
-      render(Juno.Editor(), df)
+        using Atom, Juno
+        render(Juno.Editor(), df)
     end
 
     dfvec = DataFrame[df for _=1:3]

--- a/test/show.jl
+++ b/test/show.jl
@@ -35,4 +35,7 @@ module TestShow
     show(io, A)
     A = DataFrames.RepeatedVector([1, 2, 3], 1, 5)
     show(io, A)
+
+    using Juno
+    @assert applicable(render, Juno.Inline(), df)
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -16,8 +16,10 @@ module TestShow
     showall(io, subdf)
     showall(io, subdf, true)
 
-    using Atom, Juno
-    render(Juno.Editor(), df)
+    if VERSION > v"0.5-"
+      using Atom, Juno
+      render(Juno.Editor(), df)
+    end
 
     dfvec = DataFrame[df for _=1:3]
     show(io, dfvec)
@@ -39,6 +41,6 @@ module TestShow
     A = DataFrames.RepeatedVector([1, 2, 3], 1, 5)
     show(io, A)
 
-    render(Juno.Editor(), df)
+    VERSION > v"0.5-" && render(Juno.Editor(), df)
 
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -39,4 +39,6 @@ module TestShow
     A = DataFrames.RepeatedVector([1, 2, 3], 1, 5)
     show(io, A)
 
+    render(Juno.Editor(), df)
+
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -17,8 +17,11 @@ module TestShow
     showall(io, subdf, true)
 
     if VERSION > v"0.5-"
-        using Atom, Juno
-        render(Juno.Editor(), df)
+        using Juno
+        out = DataFrames._render(df)
+        @assert out.head.xs[1] == DataFrame
+        @assert isa(out.children()[1], Juno.Table)
+        @assert size(out.children()[1].xs) == (4, 2)
     end
 
     dfvec = DataFrame[df for _=1:3]
@@ -40,7 +43,5 @@ module TestShow
     show(io, A)
     A = DataFrames.RepeatedVector([1, 2, 3], 1, 5)
     show(io, A)
-
-    VERSION > v"0.5-" && render(Juno.Editor(), df)
 
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -16,6 +16,9 @@ module TestShow
     showall(io, subdf)
     showall(io, subdf, true)
 
+    using Atom, Juno
+    render(Juno.Editor(), df)
+
     dfvec = DataFrame[df for _=1:3]
     show(io, dfvec)
     showall(io, dfvec)
@@ -36,6 +39,4 @@ module TestShow
     A = DataFrames.RepeatedVector([1, 2, 3], 1, 5)
     show(io, A)
 
-    using Juno
-    @assert applicable(render, Juno.Inline(), df)
 end


### PR DESCRIPTION
This patch adds an extremely lightweight dependency on Juno.jl, and implements rich display inside of Juno, like so:

<img width="660" alt="screenshot 2016-11-02 19 11 33" src="https://cloud.githubusercontent.com/assets/2234614/19943873/42ce21cc-a131-11e6-80f4-4adf468d41b0.png">


In future I'd like to improve on this by having access to the entire dataframe rather than truncating it, but this is something for now.