### PR TITLE
ENH: stack: allow naming of measure/value column names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ test/data/bigrams.tsv
 docs/build/
 docs/site/
 .DS_Store
-# Vim/vi
-.*.sw?

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ test/data/bigrams.tsv
 docs/build/
 docs/site/
 .DS_Store
+# Vim/vi
+.*.sw?

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -18,16 +18,10 @@ Stacks a DataFrame; convert from a wide to long format
 
 
 ```julia
-stack(df::AbstractDataFrame, measure_vars, id_vars;
-      measure_name=:variable, value_name=:value)
-stack(df::AbstractDataFrame, measure_vars;
-      measure_name=:variable, value_name=:value)
-stack(df::AbstractDataFrame;
-      measure_name=:variable, value_name=:value)
-melt(df::AbstractDataFrame, id_vars, measure_vars;
-     measure_name=:variable, value_name=:value)
-melt(df::AbstractDataFrame, id_vars;
-     measure_name=:variable, value_name=:value)
+stack(df::AbstractDataFrame, [measure_vars], [id_vars];
+      measure_name::Symbol=:variable, value_name::Symbol=:value)
+melt(df::AbstractDataFrame, [id_vars], [measure_vars];
+     measure_name::Symbol=:variable, value_name::Symbol=:value)
 ```
 
 ### Arguments
@@ -81,7 +75,8 @@ d1s_name = melt(d1, [:a, :b, :e], measure_name=:somemeasure)
 
 """
 function stack(df::AbstractDataFrame, measure_vars::Vector{Int},
-               id_vars::Vector{Int}; measure_name=:variable, value_name=:value)
+               id_vars::Vector{Int}; measure_name::Symbol=:variable,
+               value_name::Symbol=:value)
     N = length(measure_vars)
     cnames = names(df)[id_vars]
     insert!(cnames, 1, value_name)
@@ -92,22 +87,22 @@ function stack(df::AbstractDataFrame, measure_vars::Vector{Int},
               cnames)
 end
 function stack(df::AbstractDataFrame, measure_var::Int, id_var::Int;
-               measure_name=:variable, value_name=:value)
+               measure_name::Symbol=:variable, value_name::Symbol=:value)
     stack(df, [measure_var], [id_var];
           measure_name=measure_name, value_name=value_name)
 end
 function stack(df::AbstractDataFrame, measure_vars::Vector{Int}, id_var::Int;
-               measure_name=:variable, value_name=:value)
+               measure_name::Symbol=:variable, value_name::Symbol=:value)
     stack(df, measure_vars, [id_var];
           measure_name=measure_name, value_name=value_name)
 end
 function stack(df::AbstractDataFrame, measure_var::Int, id_vars::Vector{Int};
-               measure_name=:variable, value_name=:value)
+               measure_name::Symbol=:variable, value_name::Symbol=:value)
     stackdf(df, [measure_var], id_vars;
             measure_name=measure_name, value_name=value_name)
 end
 function stack(df::AbstractDataFrame, measure_vars, id_vars;
-               measure_name=:variable, value_name=:value)
+               measure_name::Symbol=:variable, value_name::Symbol=:value)
     stack(df, index(df)[measure_vars], index(df)[id_vars];
           measure_name=measure_name, value_name=value_name)
 end
@@ -117,7 +112,7 @@ numeric_vars(df::AbstractDataFrame) =
      for T in eltypes(df)]
 
 function stack(df::AbstractDataFrame, measure_vars = numeric_vars(df);
-               measure_name=:variable, value_name=:value)
+               measure_name::Symbol=:variable, value_name::Symbol=:value)
     mv_inds = index(df)[measure_vars]
     stack(df, mv_inds, _setdiff(1:ncol(df), mv_inds);
           measure_name=measure_name, value_name=value_name)
@@ -128,21 +123,21 @@ Stacks a DataFrame; convert from a wide to long format; see
 `stack`.
 """
 function melt(df::AbstractDataFrame, id_vars::@compat(Union{Int,Symbol});
-              measure_name=:variable, value_name=:value)
+              measure_name::Symbol=:variable, value_name::Symbol=:value)
     melt(df, [id_vars]; measure_name=measure_name, value_name=value_name)
 end
 function melt(df::AbstractDataFrame, id_vars;
-              measure_name=:variable, value_name=:value)
+              measure_name::Symbol=:variable, value_name::Symbol=:value)
     id_inds = index(df)[id_vars]
     stack(df, _setdiff(1:ncol(df), id_inds), id_inds;
           measure_name=measure_name, value_name=value_name)
 end
 function melt(df::AbstractDataFrame, id_vars, measure_vars;
-              measure_name=:variable, value_name=:value)
+              measure_name::Symbol=:variable, value_name::Symbol=:value)
     stack(df, measure_vars, id_vars; measure_name=measure_name,
           value_name=value_name)
 end
-melt(df::AbstractDataFrame; measure_name=:variable, value_name=:value) =
+melt(df::AbstractDataFrame; measure_name::Symbol=:variable, value_name::Symbol=:value) =
     stack(df; measure_name=measure_name, value_name=value_name)
 
 ##############################################################################
@@ -412,10 +407,10 @@ Like `stack` and `melt`, but a view is returned rather than data
 copies.
 
 ```julia
-stackdf(df::AbstractDataFrame, measure_vars, id_vars)
-stackdf(df::AbstractDataFrame, measure_vars)
-meltdf(df::AbstractDataFrame, id_vars, measure_vars)
-meltdf(df::AbstractDataFrame, id_vars)
+stackdf(df::AbstractDataFrame, [measure_vars], [id_vars];
+        measure_name::Symbol=:variable, value_name::Symbol=:value)
+meltdf(df::AbstractDataFrame, [id_vars], [measure_vars];
+       measure_name::Symbol=:variable, value_name::Symbol=:value)
 ```
 
 ### Arguments
@@ -509,5 +504,5 @@ function meltdf(df::AbstractDataFrame, id_vars, measure_vars;
     stackdf(df, measure_vars, id_vars; measure_name=measure_name,
             value_name=value_name)
 end
-meltdf(df::AbstractDataFrame; measure_name=:variable, value_name=:value) =
+meltdf(df::AbstractDataFrame; measure_name::Symbol=:variable, value_name::Symbol=:value) =
     stackdf(df; measure_name=measure_name, value_name=value_name)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -18,11 +18,11 @@ Stacks a DataFrame; convert from a wide to long format
 
 
 ```julia
-stack(df::AbstractDataFrame, measure_vars, id_vars)
-stack(df::AbstractDataFrame, measure_vars)
-stack(df::AbstractDataFrame)
-melt(df::AbstractDataFrame, id_vars, measure_vars)
-melt(df::AbstractDataFrame, id_vars)
+stack(df::AbstractDataFrame, measure_vars, id_vars; measure_name=:variable, value_name=:value)
+stack(df::AbstractDataFrame, measure_vars; measure_name=:variable, value_name=:value)
+stack(df::AbstractDataFrame; measure_name=:variable, value_name=:value)
+melt(df::AbstractDataFrame, id_vars, measure_vars; measure_name=:variable, value_name=:value)
+melt(df::AbstractDataFrame, id_vars; measure_name=:variable, value_name=:value)
 ```
 
 ### Arguments
@@ -38,8 +38,13 @@ melt(df::AbstractDataFrame, id_vars)
   stacking, a normal column indexing type; for `stack` defaults to all
   variables that are not `measure_vars`
 
+
 If neither `measure_vars` or `id_vars` are given, `measure_vars`
 defaults to all floating point columns.
+
+The names of the resulting "stacked" columns can be controlled with keyword
+arguments `measure_name` and `value_name`. These default to `:variable` and
+`:value` respectively.
 
 ### Result
 
@@ -68,33 +73,38 @@ d1m = melt(d1, [:a, :b, :e])
 ```
 
 """
-function stack(df::AbstractDataFrame, measure_vars::Vector{Int}, id_vars::Vector{Int})
+function stack(df::AbstractDataFrame, measure_vars::Vector{Int}, id_vars::Vector{Int}; measure_name=:variable, value_name=:value)
     N = length(measure_vars)
     cnames = names(df)[id_vars]
-    insert!(cnames, 1, :value)
-    insert!(cnames, 1, :variable)
+    insert!(cnames, 1, value_name)
+    insert!(cnames, 1, measure_name)
     DataFrame(Any[Compat.repeat(_names(df)[measure_vars], inner=nrow(df)),   # variable
                   vcat([df[c] for c in measure_vars]...),                    # value
                   [Compat.repeat(df[c], outer=N) for c in id_vars]...],      # id_var columns
               cnames)
 end
-function stack(df::AbstractDataFrame, measure_var::Int, id_var::Int)
-    stack(df, [measure_var], [id_var])
+function stack(df::AbstractDataFrame, measure_var::Int, id_var::Int; measure_name=:variable, value_name=:value)
+    stack(df, [measure_var], [id_var];
+          measure_name=measure_name, value_name=value_name)
 end
-function stack(df::AbstractDataFrame, measure_vars::Vector{Int}, id_var::Int)
-    stack(df, measure_vars, [id_var])
+function stack(df::AbstractDataFrame, measure_vars::Vector{Int}, id_var::Int; measure_name=:variable, value_name=:value)
+    stack(df, measure_vars, [id_var];
+          measure_name=measure_name, value_name=value_name)
 end
-function stack(df::AbstractDataFrame, measure_var::Int, id_vars::Vector{Int})
-    stackdf(df, [measure_var], id_vars)
+function stack(df::AbstractDataFrame, measure_var::Int, id_vars::Vector{Int}; measure_name=:variable, value_name=:value)
+    stackdf(df, [measure_var], id_vars;
+            measure_name=measure_name, value_name=value_name)
 end
-stack(df::AbstractDataFrame, measure_vars, id_vars) =
-    stack(df, index(df)[measure_vars], index(df)[id_vars])
+stack(df::AbstractDataFrame, measure_vars, id_vars; measure_name=:variable, value_name=:value) =
+    stack(df, index(df)[measure_vars], index(df)[id_vars];
+          measure_name=measure_name, value_name=value_name)
 # no vars specified, by default select only numeric columns
 numeric_vars(df::AbstractDataFrame) = [T <: AbstractFloat || (T <: Nullable && eltype(T) <: AbstractFloat)
                                        for T in eltypes(df)]
-function stack(df::AbstractDataFrame, measure_vars = numeric_vars(df))
+function stack(df::AbstractDataFrame, measure_vars = numeric_vars(df); measure_name=:variable, value_name=:value)
     mv_inds = index(df)[measure_vars]
-    stack(df, mv_inds, _setdiff(1:ncol(df), mv_inds))
+    stack(df, mv_inds, _setdiff(1:ncol(df), mv_inds);
+          measure_name=measure_name, value_name=value_name)
 end
 
 """
@@ -102,9 +112,10 @@ Stacks a DataFrame; convert from a wide to long format; see
 `stack`.
 """
 melt(df::AbstractDataFrame, id_vars::@compat(Union{Int,Symbol})) = melt(df, [id_vars])
-function melt(df::AbstractDataFrame, id_vars)
+function melt(df::AbstractDataFrame, id_vars; measure_name=:variable, value_name=:value)
     id_inds = index(df)[id_vars]
-    stack(df, _setdiff(1:ncol(df), id_inds), id_inds)
+    stack(df, _setdiff(1:ncol(df), id_inds), id_inds;
+          measure_name=measure_name, value_name=value_name)
 end
 melt(df::AbstractDataFrame, id_vars, measure_vars) = stack(df, measure_vars, id_vars)
 melt(df::AbstractDataFrame) = stack(df)
@@ -420,29 +431,40 @@ d1m = meltdf(d1, [:a, :b, :e])
 ```
 
 """
-function stackdf(df::AbstractDataFrame, measure_vars::Vector{Int}, id_vars::Vector{Int})
+function stackdf(df::AbstractDataFrame, measure_vars::Vector{Int},
+                 id_vars::Vector{Int}; measure_name::Symbol=:variable,
+                 value_name::Symbol=:value)
     N = length(measure_vars)
     cnames = names(df)[id_vars]
-    insert!(cnames, 1, :value)
-    insert!(cnames, 1, :variable)
+    insert!(cnames, 1, value_name)
+    insert!(cnames, 1, measure_name)
     DataFrame(Any[RepeatedVector(_names(df)[measure_vars], nrow(df), 1),   # variable
                   StackedVector(Any[df[:,c] for c in measure_vars]),     # value
                   [RepeatedVector(df[:,c], 1, N) for c in id_vars]...],     # id_var columns
               cnames)
 end
-function stackdf(df::AbstractDataFrame, measure_var::Int, id_var::Int)
-    stackdf(df, [measure_var], [id_var])
+function stackdf(df::AbstractDataFrame, measure_var::Int, id_var::Int; measure_name::Symbol=:variable,
+                 value_name::Symbol=:value)
+    stackdf(df, [measure_var], [id_var];
+            measure_name=measure_name, value_name=value_name)
 end
-function stackdf(df::AbstractDataFrame, measure_vars, id_var::Int)
-    stackdf(df, measure_vars, [id_var])
+function stackdf(df::AbstractDataFrame, measure_vars, id_var::Int; measure_name::Symbol=:variable,
+                 value_name::Symbol=:value)
+    stackdf(df, measure_vars, [id_var];
+            measure_name=measure_name, value_name=value_name)
 end
-function stackdf(df::AbstractDataFrame, measure_var::Int, id_vars)
-    stackdf(df, [measure_var], id_vars)
+function stackdf(df::AbstractDataFrame, measure_var::Int, id_vars; measure_name::Symbol=:variable,
+                 value_name::Symbol=:value)
+    stackdf(df, [measure_var], id_vars;
+            measure_name=measure_name, value_name=value_name)
 end
-function stackdf(df::AbstractDataFrame, measure_vars, id_vars)
-    stackdf(df, index(df)[measure_vars], index(df)[id_vars])
+function stackdf(df::AbstractDataFrame, measure_vars, id_vars; measure_name::Symbol=:variable,
+                 value_name::Symbol=:value)
+    stackdf(df, index(df)[measure_vars], index(df)[id_vars];
+            measure_name=measure_name, value_name=value_name)
 end
-function stackdf(df::AbstractDataFrame, measure_vars = numeric_vars(df))
+function stackdf(df::AbstractDataFrame, measure_vars = numeric_vars(df); measure_name::Symbol=:variable,
+                 value_name::Symbol=:value)
     m_inds = index(df)[measure_vars]
     stackdf(df, m_inds, _setdiff(1:ncol(df), m_inds))
 end

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -19,9 +19,9 @@ Stacks a DataFrame; convert from a wide to long format
 
 ```julia
 stack(df::AbstractDataFrame, [measure_vars], [id_vars];
-      measure_name::Symbol=:variable, value_name::Symbol=:value)
+      variable_name::Symbol=:variable, value_name::Symbol=:value)
 melt(df::AbstractDataFrame, [id_vars], [measure_vars];
-     measure_name::Symbol=:variable, value_name::Symbol=:value)
+     variable_name::Symbol=:variable, value_name::Symbol=:value)
 ```
 
 ### Arguments
@@ -39,7 +39,7 @@ melt(df::AbstractDataFrame, [id_vars], [measure_vars];
   stacking, a normal column indexing type; for `stack` defaults to all
   variables that are not `measure_vars`
 
-* `measure_name` : the name of the new stacked column that shall hold the names
+* `variable_name` : the name of the new stacked column that shall hold the names
   of each of `measure_vars`
 
 * `value_name` : the name of the new stacked column containing the values from
@@ -70,41 +70,41 @@ d1 = DataFrame(a = repeat([1:3;], inner = [4]),
 d1s = stack(d1, [:c, :d])
 d1s2 = stack(d1, [:c, :d], [:a])
 d1m = melt(d1, [:a, :b, :e])
-d1s_name = melt(d1, [:a, :b, :e], measure_name=:somemeasure)
+d1s_name = melt(d1, [:a, :b, :e], variable_name=:somemeasure)
 ```
 
 """
 function stack(df::AbstractDataFrame, measure_vars::Vector{Int},
-               id_vars::Vector{Int}; measure_name::Symbol=:variable,
+               id_vars::Vector{Int}; variable_name::Symbol=:variable,
                value_name::Symbol=:value)
     N = length(measure_vars)
     cnames = names(df)[id_vars]
     insert!(cnames, 1, value_name)
-    insert!(cnames, 1, measure_name)
+    insert!(cnames, 1, variable_name)
     DataFrame(Any[Compat.repeat(_names(df)[measure_vars], inner=nrow(df)),   # variable
                   vcat([df[c] for c in measure_vars]...),                    # value
                   [Compat.repeat(df[c], outer=N) for c in id_vars]...],      # id_var columns
               cnames)
 end
 function stack(df::AbstractDataFrame, measure_var::Int, id_var::Int;
-               measure_name::Symbol=:variable, value_name::Symbol=:value)
+               variable_name::Symbol=:variable, value_name::Symbol=:value)
     stack(df, [measure_var], [id_var];
-          measure_name=measure_name, value_name=value_name)
+          variable_name=variable_name, value_name=value_name)
 end
 function stack(df::AbstractDataFrame, measure_vars::Vector{Int}, id_var::Int;
-               measure_name::Symbol=:variable, value_name::Symbol=:value)
+               variable_name::Symbol=:variable, value_name::Symbol=:value)
     stack(df, measure_vars, [id_var];
-          measure_name=measure_name, value_name=value_name)
+          variable_name=variable_name, value_name=value_name)
 end
 function stack(df::AbstractDataFrame, measure_var::Int, id_vars::Vector{Int};
-               measure_name::Symbol=:variable, value_name::Symbol=:value)
+               variable_name::Symbol=:variable, value_name::Symbol=:value)
     stackdf(df, [measure_var], id_vars;
-            measure_name=measure_name, value_name=value_name)
+            variable_name=variable_name, value_name=value_name)
 end
 function stack(df::AbstractDataFrame, measure_vars, id_vars;
-               measure_name::Symbol=:variable, value_name::Symbol=:value)
+               variable_name::Symbol=:variable, value_name::Symbol=:value)
     stack(df, index(df)[measure_vars], index(df)[id_vars];
-          measure_name=measure_name, value_name=value_name)
+          variable_name=variable_name, value_name=value_name)
 end
 # no vars specified, by default select only numeric columns
 numeric_vars(df::AbstractDataFrame) =
@@ -112,10 +112,10 @@ numeric_vars(df::AbstractDataFrame) =
      for T in eltypes(df)]
 
 function stack(df::AbstractDataFrame, measure_vars = numeric_vars(df);
-               measure_name::Symbol=:variable, value_name::Symbol=:value)
+               variable_name::Symbol=:variable, value_name::Symbol=:value)
     mv_inds = index(df)[measure_vars]
     stack(df, mv_inds, _setdiff(1:ncol(df), mv_inds);
-          measure_name=measure_name, value_name=value_name)
+          variable_name=variable_name, value_name=value_name)
 end
 
 """
@@ -123,22 +123,22 @@ Stacks a DataFrame; convert from a wide to long format; see
 `stack`.
 """
 function melt(df::AbstractDataFrame, id_vars::@compat(Union{Int,Symbol});
-              measure_name::Symbol=:variable, value_name::Symbol=:value)
-    melt(df, [id_vars]; measure_name=measure_name, value_name=value_name)
+              variable_name::Symbol=:variable, value_name::Symbol=:value)
+    melt(df, [id_vars]; variable_name=variable_name, value_name=value_name)
 end
 function melt(df::AbstractDataFrame, id_vars;
-              measure_name::Symbol=:variable, value_name::Symbol=:value)
+              variable_name::Symbol=:variable, value_name::Symbol=:value)
     id_inds = index(df)[id_vars]
     stack(df, _setdiff(1:ncol(df), id_inds), id_inds;
-          measure_name=measure_name, value_name=value_name)
+          variable_name=variable_name, value_name=value_name)
 end
 function melt(df::AbstractDataFrame, id_vars, measure_vars;
-              measure_name::Symbol=:variable, value_name::Symbol=:value)
-    stack(df, measure_vars, id_vars; measure_name=measure_name,
+              variable_name::Symbol=:variable, value_name::Symbol=:value)
+    stack(df, measure_vars, id_vars; variable_name=variable_name,
           value_name=value_name)
 end
-melt(df::AbstractDataFrame; measure_name::Symbol=:variable, value_name::Symbol=:value) =
-    stack(df; measure_name=measure_name, value_name=value_name)
+melt(df::AbstractDataFrame; variable_name::Symbol=:variable, value_name::Symbol=:value) =
+    stack(df; variable_name=variable_name, value_name=value_name)
 
 ##############################################################################
 ##
@@ -408,9 +408,9 @@ copies.
 
 ```julia
 stackdf(df::AbstractDataFrame, [measure_vars], [id_vars];
-        measure_name::Symbol=:variable, value_name::Symbol=:value)
+        variable_name::Symbol=:variable, value_name::Symbol=:value)
 meltdf(df::AbstractDataFrame, [id_vars], [measure_vars];
-       measure_name::Symbol=:variable, value_name::Symbol=:value)
+       variable_name::Symbol=:variable, value_name::Symbol=:value)
 ```
 
 ### Arguments
@@ -452,57 +452,57 @@ d1m = meltdf(d1, [:a, :b, :e])
 
 """
 function stackdf(df::AbstractDataFrame, measure_vars::Vector{Int},
-                 id_vars::Vector{Int}; measure_name::Symbol=:variable,
+                 id_vars::Vector{Int}; variable_name::Symbol=:variable,
                  value_name::Symbol=:value)
     N = length(measure_vars)
     cnames = names(df)[id_vars]
     insert!(cnames, 1, value_name)
-    insert!(cnames, 1, measure_name)
+    insert!(cnames, 1, variable_name)
     DataFrame(Any[RepeatedVector(_names(df)[measure_vars], nrow(df), 1),   # variable
                   StackedVector(Any[df[:,c] for c in measure_vars]),     # value
                   [RepeatedVector(df[:,c], 1, N) for c in id_vars]...],     # id_var columns
               cnames)
 end
 function stackdf(df::AbstractDataFrame, measure_var::Int, id_var::Int;
-                 measure_name::Symbol=:variable, value_name::Symbol=:value)
-    stackdf(df, [measure_var], [id_var]; measure_name=measure_name,
+                 variable_name::Symbol=:variable, value_name::Symbol=:value)
+    stackdf(df, [measure_var], [id_var]; variable_name=variable_name,
             value_name=value_name)
 end
 function stackdf(df::AbstractDataFrame, measure_vars, id_var::Int;
-                 measure_name::Symbol=:variable, value_name::Symbol=:value)
-    stackdf(df, measure_vars, [id_var]; measure_name=measure_name,
+                 variable_name::Symbol=:variable, value_name::Symbol=:value)
+    stackdf(df, measure_vars, [id_var]; variable_name=variable_name,
             value_name=value_name)
 end
 function stackdf(df::AbstractDataFrame, measure_var::Int, id_vars;
-                 measure_name::Symbol=:variable, value_name::Symbol=:value)
-    stackdf(df, [measure_var], id_vars; measure_name=measure_name,
+                 variable_name::Symbol=:variable, value_name::Symbol=:value)
+    stackdf(df, [measure_var], id_vars; variable_name=variable_name,
             value_name=value_name)
 end
 function stackdf(df::AbstractDataFrame, measure_vars, id_vars;
-                 measure_name::Symbol=:variable, value_name::Symbol=:value)
+                 variable_name::Symbol=:variable, value_name::Symbol=:value)
     stackdf(df, index(df)[measure_vars], index(df)[id_vars];
-            measure_name=measure_name, value_name=value_name)
+            variable_name=variable_name, value_name=value_name)
 end
 function stackdf(df::AbstractDataFrame, measure_vars = numeric_vars(df);
-                 measure_name::Symbol=:variable, value_name::Symbol=:value)
+                 variable_name::Symbol=:variable, value_name::Symbol=:value)
     m_inds = index(df)[measure_vars]
     stackdf(df, m_inds, _setdiff(1:ncol(df), m_inds);
-            measure_name=measure_name, value_name=value_name)
+            variable_name=variable_name, value_name=value_name)
 end
 
 """
 A stacked view of a DataFrame (long format); see `stackdf`
 """
-function meltdf(df::AbstractDataFrame, id_vars; measure_name::Symbol=:variable,
+function meltdf(df::AbstractDataFrame, id_vars; variable_name::Symbol=:variable,
                 value_name::Symbol=:value)
     id_inds = index(df)[id_vars]
     stackdf(df, _setdiff(1:ncol(df), id_inds), id_inds;
-            measure_name=measure_name, value_name=value_name)
+            variable_name=variable_name, value_name=value_name)
 end
 function meltdf(df::AbstractDataFrame, id_vars, measure_vars;
-                measure_name::Symbol=:variable, value_name::Symbol=:value)
-    stackdf(df, measure_vars, id_vars; measure_name=measure_name,
+                variable_name::Symbol=:variable, value_name::Symbol=:value)
+    stackdf(df, measure_vars, id_vars; variable_name=variable_name,
             value_name=value_name)
 end
-meltdf(df::AbstractDataFrame; measure_name::Symbol=:variable, value_name::Symbol=:value) =
-    stackdf(df; measure_name=measure_name, value_name=value_name)
+meltdf(df::AbstractDataFrame; variable_name::Symbol=:variable, value_name::Symbol=:value) =
+    stackdf(df; variable_name=variable_name, value_name=value_name)

--- a/test/data.jl
+++ b/test/data.jl
@@ -150,9 +150,9 @@ module TestData
     @test names(d1m) == [:variable, :value, :a]
 
     # Test naming of measure/value columns
-    d1s_named = stack(d1, [:a, :b], measure_name=:letter, value_name=:someval)
+    d1s_named = stack(d1, [:a, :b], variable_name=:letter, value_name=:someval)
     @test names(d1s_named) == [:letter, :someval, :c, :d, :e]
-    d1m_named = melt(d1[[1,3,4]], :a, measure_name=:letter, value_name=:someval)
+    d1m_named = melt(d1[[1,3,4]], :a, variable_name=:letter, value_name=:someval)
     @test names(d1m_named) == [:letter, :someval, :a]
 
     stackdf(d1, :a)
@@ -168,9 +168,9 @@ module TestData
     d1m = meltdf(d1[[1,3,4]], :a)
     @test names(d1m) == [:variable, :value, :a]
 
-    d1s_named = stackdf(d1, [:a, :b], measure_name=:letter, value_name=:someval)
+    d1s_named = stackdf(d1, [:a, :b], variable_name=:letter, value_name=:someval)
     @test names(d1s_named) == [:letter, :someval, :c, :d, :e]
-    d1m_named = meltdf(d1, [:c, :d, :e], measure_name=:letter, value_name=:someval)
+    d1m_named = meltdf(d1, [:c, :d, :e], variable_name=:letter, value_name=:someval)
     @test names(d1m_named) == [:letter, :someval, :c, :d, :e]
 
     d1s[:id] = [1:12; 1:12]

--- a/test/data.jl
+++ b/test/data.jl
@@ -149,6 +149,12 @@ module TestData
     d1m = melt(d1[[1,3,4]], :a)
     @test names(d1m) == [:variable, :value, :a]
 
+    # Test naming of measure/value columns
+    d1s_named = stack(d1, [:a, :b], measure_name=:letter, value_name=:someval)
+    @test names(d1s_named) == [:letter, :someval, :c, :d, :e]
+    d1m_named = melt(d1[[1,3,4]], :a, measure_name=:letter)
+    @test names(d1m_named) == [:letter, :value, :a]
+
     stackdf(d1, :a)
     d1s = stackdf(d1, [:a, :b])
     d1s2 = stackdf(d1, [:c, :d])

--- a/test/data.jl
+++ b/test/data.jl
@@ -152,8 +152,8 @@ module TestData
     # Test naming of measure/value columns
     d1s_named = stack(d1, [:a, :b], measure_name=:letter, value_name=:someval)
     @test names(d1s_named) == [:letter, :someval, :c, :d, :e]
-    d1m_named = melt(d1[[1,3,4]], :a, measure_name=:letter)
-    @test names(d1m_named) == [:letter, :value, :a]
+    d1m_named = melt(d1[[1,3,4]], :a, measure_name=:letter, value_name=:someval)
+    @test names(d1m_named) == [:letter, :someval, :a]
 
     stackdf(d1, :a)
     d1s = stackdf(d1, [:a, :b])
@@ -167,6 +167,11 @@ module TestData
     @test isequal(d1s, d1m)
     d1m = meltdf(d1[[1,3,4]], :a)
     @test names(d1m) == [:variable, :value, :a]
+
+    d1s_named = stackdf(d1, [:a, :b], measure_name=:letter, value_name=:someval)
+    @test names(d1s_named) == [:letter, :someval, :c, :d, :e]
+    d1m_named = meltdf(d1, [:c, :d, :e], measure_name=:letter, value_name=:someval)
+    @test names(d1m_named) == [:letter, :someval, :c, :d, :e]
 
     d1s[:id] = [1:12; 1:12]
     d1s2[:id] = [1:12; 1:12]


### PR DESCRIPTION
In R's `reshape2::melt`  it is possible to use a custom name for the newly created stacked columns. This adds two optional keyword arguments that allow this behaviour (demonstrated below).

I have added tests, but I would like to see if I can simplify the diff. I'd like to avoid having to define these kwargs for all the various `stack` and `melt` invocations (suggestions welcome).

## TODO:

- [x] ~Decide on final name for keyword arguments: `variable_name` vs `measure_name`.~ Decision: `variable_name`


```julia
julia> d = DataFrame(red=rand(2), blue=rand(2), green=rand(2), sample=["A", "B"])
2×4 DataFrames.DataFrame
│ Row │ red      │ blue     │ green    │ sample │
├─────┼──────────┼──────────┼──────────┼────────┤
│ 1   │ 0.134251 │ 0.668584 │ 0.463817 │ A      │
│ 2   │ 0.784527 │ 0.46851  │ 0.634924 │ B      │

julia> ds = stack(d, [:red, :blue, :green])
6×3 DataFrames.DataFrame
│ Row │ variable │ value    │ sample │
├─────┼──────────┼──────────┼────────┤
│ 1   │ red      │ 0.134251 │ A      │
│ 2   │ red      │ 0.784527 │ B      │
│ 3   │ blue     │ 0.668584 │ A      │
│ 4   │ blue     │ 0.46851  │ B      │
│ 5   │ green    │ 0.463817 │ A      │
│ 6   │ green    │ 0.634924 │ B      │

julia> dsn = stack(d, [:red, :blue, :green], variable_name=:colour,
                   value_name=:mean_pixel_value)
6×3 DataFrames.DataFrame
│ Row │ colour │ mean_pixel_value │ sample │
├─────┼────────┼──────────────────┼────────┤
│ 1   │ red    │ 0.134251         │ A      │
│ 2   │ red    │ 0.784527         │ B      │
│ 3   │ blue   │ 0.668584         │ A      │
│ 4   │ blue   │ 0.46851          │ B      │
│ 5   │ green  │ 0.463817         │ A      │
│ 6   │ green  │ 0.634924         │ B      │
```