### PR TITLE
Fix computation of column width for Array{String} columns

### DIFF
--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -37,7 +37,7 @@ let
         ourshowcompact(io, x)
         return position(io)
     end
-    ourstrwidth(x::AbstractString) = strwidth(x) + 2 # -> Int
+    ourstrwidth(x::AbstractString) = strwidth(x) # -> Int
     myconv = VERSION < v"0.4-" ? convert : Base.unsafe_convert
     ourstrwidth(s::Symbol) =
         @compat Int(ccall(:u8_strwidth,

--- a/test/show.jl
+++ b/test/show.jl
@@ -49,11 +49,22 @@ module TestShow
     df = DataFrame(Fish = ["Suzy", "Amir"], Mass = [1.5, Nullable()])
     io = IOBuffer()
     show(io, df)
-    str = takebuf_string(io)
+    str = String(take!(io))
     @test str == """
-2×2 DataFrames.DataFrame
-│ Row │ Fish │ Mass  │
-├─────┼──────┼───────┤
-│ 1   │ Suzy │ 1.5   │
-│ 2   │ Amir │ #NULL │"""
+    2×2 DataFrames.DataFrame
+    │ Row │ Fish │ Mass  │
+    ├─────┼──────┼───────┤
+    │ 1   │ Suzy │ 1.5   │
+    │ 2   │ Amir │ #NULL │"""
+
+    # Test computing width for Array{String} columns
+    df = DataFrame(Any[["a"]], [:x])
+    io = IOBuffer()
+    show(io, df)
+    str = String(take!(io))
+    @test str == """
+    1×1 DataFrames.DataFrame
+    │ Row │ x │
+    ├─────┼───┤
+    │ 1   │ a │"""
 end


### PR DESCRIPTION
These are rare enough to be untested, and Strings have a fast path which
is different from Nullable{String}. The +2 must be a remnant from a time when
we printed the quotes.

By the way, fix indentation and a deprecation in the previous example, which
is similar.

(Errors on nightlies are unrelated.)