### PR TITLE
Fix stack() example in manual

### DIFF
--- a/docs/src/man/reshaping_and_pivoting.md
+++ b/docs/src/man/reshaping_and_pivoting.md
@@ -6,7 +6,7 @@ Reshape data from wide to long format using the `stack` function:
 using DataFrames, RDatasets
 iris = dataset("datasets", "iris")
 iris[:id] = 1:size(iris, 1)  # this makes it easier to unstack
-d = stack(iris, [1:4])
+d = stack(iris, 1:4)
 ```
 
 The second optional argument to `stack` indicates the columns to be stacked. These are normally referred to as the measured variables. Column names can also be given:


### PR DESCRIPTION
This example has not been updated after [1:4] stopped returning a Vector{Int}
in Julia 0.5.

Fixes https://github.com/JuliaStats/DataFrames.jl/issues/1162.