### PR TITLE
Replace bare tilde with formula macro

### DIFF
--- a/docs/src/man/formulas.md
+++ b/docs/src/man/formulas.md
@@ -1,22 +1,22 @@
 # The Formula, ModelFrame and ModelMatrix Types
 
-In regression analysis, we often want to describe the relationship between a response variable and one or more input variables in terms of main effects and interactions. To facilitate the specification of a regression model in terms of the columns of a `DataFrame`, the DataFrames package provides a `Formula` type, which is created by the `~` binary operator in Julia:
+In regression analysis, we often want to describe the relationship between a response variable and one or more input variables in terms of main effects and interactions. To facilitate the specification of a regression model in terms of the columns of a `DataFrame`, the DataFrames package provides a `Formula` type, which is created using the `@formula` macro in Julia:
 
 ```julia
-fm = Z ~ X + Y
+fm = @formula(Z ~ X + Y)
 ```
 
 A `Formula` object can be used to transform a `DataFrame` into a `ModelFrame` object:
 
 ```julia
 df = DataFrame(X = randn(10), Y = randn(10), Z = randn(10))
-mf = ModelFrame(Z ~ X + Y, df)
+mf = ModelFrame(@formula(Z ~ X + Y), df)
 ```
 
 A `ModelFrame` object is just a simple wrapper around a `DataFrame`. For modeling purposes, one generally wants to construct a `ModelMatrix`, which constructs a `Matrix{Float64}` that can be used directly to fit a statistical model:
 
 ```julia
-mm = ModelMatrix(ModelFrame(Z ~ X + Y, df))
+mm = ModelMatrix(ModelFrame(@formula(Z ~ X + Y), df))
 ```
 
 Note that `mm` contains an additional column consisting entirely of `1.0` values. This is used to fit an intercept term in a regression model.
@@ -24,25 +24,25 @@ Note that `mm` contains an additional column consisting entirely of `1.0` values
 In addition to specifying main effects, it is possible to specify interactions using the `&` operator inside a `Formula`:
 
 ```julia
-mm = ModelMatrix(ModelFrame(Z ~ X + Y + X&Y, df))
+mm = ModelMatrix(ModelFrame(@formula(Z ~ X + Y + X&Y), df))
 ```
 
 If you would like to specify both main effects and an interaction term at once, use the `*` operator inside a \`Formula\`:
 
 ```julia
-mm = ModelMatrix(ModelFrame(Z ~ X*Y, df))
+mm = ModelMatrix(ModelFrame(@formula(Z ~ X*Y), df))
 ```
 
 You can control how categorical variables (e.g., `PooledDataArray` columns) are converted to `ModelMatrix` columns by specifying _contrasts_ when you construct a `ModelFrame`:
 
 ```julia
-mm = ModelMatrix(ModelFrame(Z ~ X*Y, df, contrasts = Dict(:X => HelmertCoding())))
+mm = ModelMatrix(ModelFrame(@formula(Z ~ X*Y), df, contrasts = Dict(:X => HelmertCoding())))
 ```
 
 Contrasts can also be modified in an existing `ModelFrame`:
 
 ```julia
-mf = ModelFrame(Z ~ X*Y, df)
+mf = ModelFrame(@formula(Z ~ X*Y), df)
 contrasts!(mf, X = HelmertCoding())
 ```
 

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -30,6 +30,7 @@ import Base: ==, |>
 export @~,
        @csv_str,
        @csv2_str,
+       @formula,
        @tsv_str,
        @wsv_str,
 

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -21,85 +21,85 @@ module TestFormula
     @test t.eterms == []
 
     ## empty RHS
-    t = Terms(y ~ 0)
+    t = Terms(@formula(y ~ 0))
     @test t.intercept == false
     @test t.terms == []
     @test t.eterms == [:y]
-    t = Terms(y ~ -1)
+    t = Terms(@formula(y ~ -1))
     @test t.intercept == false
     @test t.terms == []
 
     ## intercept-only
-    t = Terms(y ~ 1)
+    t = Terms(@formula(y ~ 1))
     @test t.response == true
     @test t.intercept == true
     @test t.terms == []
     @test t.eterms == [:y]
 
     ## terms add
-    t = Terms(y ~ 1 + x1 + x2)
+    t = Terms(@formula(y ~ 1 + x1 + x2))
     @test t.intercept == true
     @test t.terms == [:x1, :x2]
     @test t.eterms == [:y, :x1, :x2]
 
     ## implicit intercept behavior:
-    t = Terms(y ~ x1 + x2)
+    t = Terms(@formula(y ~ x1 + x2))
     @test t.intercept == true
     @test t.terms == [:x1, :x2]
     @test t.eterms == [:y, :x1, :x2]
 
     ## no intercept
-    t = Terms(y ~ 0 + x1 + x2)
+    t = Terms(@formula(y ~ 0 + x1 + x2))
     @test t.intercept == false
     @test t.terms == [:x1, :x2]
 
-    t = Terms(y ~ -1 + x1 + x2)
+    t = Terms(@formula(y ~ -1 + x1 + x2))
     @test t.intercept == false
     @test t.terms == [:x1, :x2]
 
-    t = Terms(y ~ x1 & x2)
+    t = Terms(@formula(y ~ x1 & x2))
     @test t.terms == [:(x1 & x2)]
     @test t.eterms == [:y, :x1, :x2]
 
     ## `*` expansion
-    t = Terms(y ~ x1 * x2)
+    t = Terms(@formula(y ~ x1 * x2))
     @test t.terms == [:x1, :x2, :(x1 & x2)]
     @test t.eterms == [:y, :x1, :x2]
 
     ## associative rule:
     ## +
-    t = Terms(y ~ x1 + x2 + x3)
+    t = Terms(@formula(y ~ x1 + x2 + x3))
     @test t.terms == [:x1, :x2, :x3]
 
     ## &
-    t = Terms(y ~ x1 & x2 & x3)
+    t = Terms(@formula(y ~ x1 & x2 & x3))
     @test t.terms == [:((&)(x1, x2, x3))]
     @test t.eterms == [:y, :x1, :x2, :x3]
 
     ## distributive property of + and &
-    t = Terms(y ~ x1 & (x2 + x3))
+    t = Terms(@formula(y ~ x1 & (x2 + x3)))
     @test t.terms == [:(x1&x2), :(x1&x3)]
 
     ## FAILS: ordering of expanded interaction terms is wrong
     ## (only has an observable effect when both terms are categorical and
     ## produce multiple model matrix columns that are multiplied together...)
     ##
-    ## t = Terms(y ~ (x2 + x3) & x1)
+    ## t = Terms(@formula(y ~ (x2 + x3) & x1))
     ## @test t.terms == [:(x2&x1), :(x3&x1)]
 
     ## three-way *
-    t = Terms(y ~ x1 * x2 * x3)
+    t = Terms(@formula(y ~ x1 * x2 * x3))
     @test t.terms == [:x1, :x2, :x3,
                       :(x1&x2), :(x1&x3), :(x2&x3),
                       :((&)(x1, x2, x3))]
     @test t.eterms == [:y, :x1, :x2, :x3]
 
     ## Interactions with `1` reduce to main effect.  All fail at the moment.
-    ## t = Terms(y ~ 1 & x1)
+    ## t = Terms(@formula(y ~ 1 & x1))
     ## @test t.terms == [:x1]              # == [:(1 & x1)]
     ## @test t.eterms == [:y, :x1]
 
-    ## t = Terms(y ~ (1 + x1) & x2)
+    ## t = Terms(@formula(y ~ (1 + x1) & x2))
     ## @test t.terms == [:x2, :(x1&x2)]    # == [:(1 & x1)]
     ## @test t.eterms == [:y, :x1, :x2]
 
@@ -120,7 +120,7 @@ module TestFormula
     x2 = [9.:12;]
     x3 = [13.:16;]
     x4 = [17.:20;]
-    f = y ~ x1 + x2
+    f = @formula(y ~ x1 + x2)
     mf = ModelFrame(f, d)
     ## @test mm.response_colnames == ["y"] # nope: no response_colnames
     @test coefnames(mf) == ["(Intercept)","x1","x2"]
@@ -138,7 +138,7 @@ module TestFormula
     #test_group("expanding a PooledVec into a design matrix of indicators for each dummy variable")
 
     d[:x1p] = PooledDataArray(d[:x1])
-    mf = ModelFrame(y ~ x1p, d)
+    mf = ModelFrame(@formula(y ~ x1p), d)
     mm = ModelMatrix(mf)
 
     @test mm.m[:,2] == [0, 1., 0, 0]
@@ -204,13 +204,13 @@ module TestFormula
     #test_group("Creating a model matrix using full formulas: y ~ x1 + x2, etc")
 
     df = deepcopy(d)
-    f = y ~ x1 & x2
+    f = @formula(y ~ x1 & x2)
     mf = ModelFrame(f, df)
     mm = ModelMatrix(mf)
     @test mm.m == [ones(4) x1.*x2]
     @test mm.m == ModelMatrix{sparsetype}(mf).m
 
-    f = y ~ x1 * x2
+    f = @formula(y ~ x1 * x2)
     mf = ModelFrame(f, df)
     mm = ModelMatrix(mf)
     @test mm.m == [ones(4) x1 x2 x1.*x2]
@@ -218,7 +218,7 @@ module TestFormula
 
     df[:x1] = PooledDataArray(x1)
     x1e = [[0, 1, 0, 0] [0, 0, 1, 0] [0, 0, 0, 1]]
-    f = y ~ x1 * x2
+    f = @formula(y ~ x1 * x2)
     mf = ModelFrame(f, df)
     mm = ModelMatrix(mf)
     @test mm.m == [ones(4) x1e x2 [0, 10, 0, 0] [0, 0, 11, 0] [0, 0, 0, 12]]
@@ -270,7 +270,7 @@ module TestFormula
 
     # additional tests from Tom
     y = [1., 2, 3, 4]
-    mf = ModelFrame(y ~ x2, d)
+    mf = ModelFrame(@formula(y ~ x2), d)
     mm = ModelMatrix(mf)
     @test mm.m == [ones(4) x2]
     @test mm.m == ModelMatrix{sparsetype}(mf).m
@@ -279,12 +279,12 @@ module TestFormula
     df = deepcopy(d)
     df[:x1] = PooledDataArray(df[:x1])
 
-    f = y ~ x2 + x3 + x3*x2
+    f = @formula(y ~ x2 + x3 + x3*x2)
     mm = ModelMatrix(ModelFrame(f, df))
     @test mm.m == [ones(4) x2 x3 x2.*x3]
-    mm = ModelMatrix(ModelFrame(y ~ x3*x2 + x2 + x3, df))
+    mm = ModelMatrix(ModelFrame(@formula(y ~ x3*x2 + x2 + x3), df))
     @test mm.m == [ones(4) x3 x2 x2.*x3]
-    mm = ModelMatrix(ModelFrame(y ~ x1 + x2 + x3 + x4, df))
+    mm = ModelMatrix(ModelFrame(@formula(y ~ x1 + x2 + x3 + x4), df))
     @test mm.m[:,2] == [0, 1., 0, 0]
     @test mm.m[:,3] == [0, 0, 1., 0]
     @test mm.m[:,4] == [0, 0, 0, 1.]
@@ -292,24 +292,24 @@ module TestFormula
     @test mm.m[:,6] == x3
     @test mm.m[:,7] == x4
 
-    mm = ModelMatrix(ModelFrame(y ~ x2 + x3 + x4, df))
+    mm = ModelMatrix(ModelFrame(@formula(y ~ x2 + x3 + x4), df))
     @test mm.m == [ones(4) x2 x3 x4]
-    mm = ModelMatrix(ModelFrame(y ~ x2 + x2, df))
+    mm = ModelMatrix(ModelFrame(@formula(y ~ x2 + x2), df))
     @test mm.m == [ones(4) x2]
-    mm = ModelMatrix(ModelFrame(y ~ x2*x3 + x2&x3, df))
+    mm = ModelMatrix(ModelFrame(@formula(y ~ x2*x3 + x2&x3), df))
     @test mm.m == [ones(4) x2 x3 x2.*x3]
-    mm = ModelMatrix(ModelFrame(y ~ x2*x3*x4, df))
+    mm = ModelMatrix(ModelFrame(@formula(y ~ x2*x3*x4), df))
     @test mm.m == [ones(4) x2 x3 x4 x2.*x3 x2.*x4 x3.*x4 x2.*x3.*x4]
-    mm = ModelMatrix(ModelFrame(y ~ x2&x3 + x2*x3, df))
+    mm = ModelMatrix(ModelFrame(@formula(y ~ x2&x3 + x2*x3), df))
     @test mm.m == [ones(4) x2 x3 x2.*x3]
 
-    f = y ~ x2 & x3 & x4
+    f = @formula(y ~ x2 & x3 & x4)
     mf = ModelFrame(f, df)
     mm = ModelMatrix(mf)
     @test mm.m == [ones(4) x2.*x3.*x4]
     @test mm.m == ModelMatrix{sparsetype}(mf).m
 
-    f = y ~ x1 & x2 & x3
+    f = @formula(y ~ x1 & x2 & x3)
     mf = ModelFrame(f, df)
     mm = ModelMatrix(mf)
     @test mm.m[:, 2:end] == diagm(x2.*x3)
@@ -357,23 +357,23 @@ module TestFormula
 
     ## Distributive property of :& over :+
     df = deepcopy(d)
-    f = y ~ (x1+x2) & (x3+x4)
+    f = @formula(y ~ (x1+x2) & (x3+x4))
     mf = ModelFrame(f, df)
     mm = ModelMatrix(mf)
     @test mm.m == hcat(ones(4), x1.*x3, x1.*x4, x2.*x3, x2.*x4)
     @test mm.m == ModelMatrix{sparsetype}(mf).m
 
     ## Condensing nested :+ calls
-    f = y ~ x1 + (x2 + (x3 + x4))
+    f = @formula(y ~ x1 + (x2 + (x3 + x4)))
     @test ModelMatrix(ModelFrame(f, df)).m == hcat(ones(4), x1, x2, x3, x4)
 
 
     ## Extra levels in categorical column
-    mf_full = ModelFrame(y ~ x1p, d)
+    mf_full = ModelFrame(@formula(y ~ x1p), d)
     mm_full = ModelMatrix(mf_full)
     @test size(mm_full) == (4,4)
 
-    mf_sub = ModelFrame(y ~ x1p, d[2:4, :])
+    mf_sub = ModelFrame(@formula(y ~ x1p), d[2:4, :])
     mm_sub = ModelMatrix(mf_sub)
     ## should have only three rows, and only three columns (intercept plus two
     ## levels of factor)
@@ -381,13 +381,13 @@ module TestFormula
 
     ## Missing data
     d[:x1m] = @data [5, 6, NA, 7]
-    mf = ModelFrame(y ~ x1m, d)
+    mf = ModelFrame(@formula(y ~ x1m), d)
     mm = ModelMatrix(mf)
     @test mm.m[:, 2] == d[complete_cases(d), :x1m]
     @test mm.m == ModelMatrix{sparsetype}(mf).m
 
     ## Same variable on left and right side
-    mf = ModelFrame(x1 ~ x1, df)
+    mf = ModelFrame(@formula(x1 ~ x1), df)
     mm = ModelMatrix(mf)
     mm.m == float(model_response(mf))
 
@@ -402,7 +402,7 @@ d[:n] = 1.:8
 
 
 ## No intercept
-mf = ModelFrame(n ~ 0 + x, d, contrasts=cs)
+mf = ModelFrame(@formula(n ~ 0 + x), d, contrasts=cs)
 mm = ModelMatrix(mf)
 @test mm.m == [1 0
                0 1
@@ -416,7 +416,7 @@ mm = ModelMatrix(mf)
 @test coefnames(mf) == ["x: a", "x: b"]
 
 ## No first-order term for interaction
-mf = ModelFrame(n ~ 1 + x + x&y, d, contrasts=cs)
+mf = ModelFrame(@formula(n ~ 1 + x + x&y), d, contrasts=cs)
 mm = ModelMatrix(mf)
 @test mm.m[:, 2:end] == [-1 -1  0
                          1  0 -1
@@ -430,7 +430,7 @@ mm = ModelMatrix(mf)
 @test coefnames(mf) == ["(Intercept)", "x: b", "x: a & y: d", "x: b & y: d"]
 
 ## When both terms of interaction are non-redundant:
-mf = ModelFrame(n ~ 0 + x&y, d, contrasts=cs)
+mf = ModelFrame(@formula(n ~ 0 + x&y), d, contrasts=cs)
 mm = ModelMatrix(mf)
 @test mm.m == [1 0 0 0
                0 1 0 0
@@ -445,7 +445,7 @@ mm = ModelMatrix(mf)
                         "x: a & y: d", "x: b & y: d"]
 
 # only a three-way interaction: every term is promoted.
-mf = ModelFrame(n ~ 0 + x&y&z, d, contrasts=cs)
+mf = ModelFrame(@formula(n ~ 0 + x&y&z), d, contrasts=cs)
 mm = ModelMatrix(mf)
 @test mm.m == eye(8)
 @test mm.m == ModelMatrix{sparsetype}(mf).m
@@ -454,7 +454,7 @@ mm = ModelMatrix(mf)
 # first (both x and y), but only the old term (x) in the second (because
 # dropping x gives z which isn't found elsewhere, but dropping z gives x
 # which is found (implicitly) in the promoted interaction x&y).
-mf = ModelFrame(n ~ 0 + x&y + x&z, d, contrasts=cs)
+mf = ModelFrame(@formula(n ~ 0 + x&y + x&z), d, contrasts=cs)
 mm = ModelMatrix(mf)
 @test mm.m == [1 0 0 0 -1  0
                0 1 0 0  0 -1
@@ -472,7 +472,7 @@ mm = ModelMatrix(mf)
 # ...and adding a three-way interaction, only the shared term (x) is promoted.
 # this is because dropping x gives y&z which isn't present, but dropping y or z
 # gives x&z or x&z respectively, which are both present.
-mf = ModelFrame(n ~ 0 + x&y + x&z + x&y&z, d, contrasts=cs)
+mf = ModelFrame(@formula(n ~ 0 + x&y + x&z + x&y&z), d, contrasts=cs)
 mm = ModelMatrix(mf)
 @test mm.m == [1 0 0 0 -1  0  1  0
                0 1 0 0  0 -1  0  1
@@ -491,7 +491,7 @@ mm = ModelMatrix(mf)
 # two two-way interactions, with common lower-order term. the common term x is
 # promoted in both (along with lower-order term), because in every case, when
 # x is dropped, the remaining terms (1, y, and z) aren't present elsewhere.
-mf = ModelFrame(n ~ 0 + x + x&y + x&z, d, contrasts=cs)
+mf = ModelFrame(@formula(n ~ 0 + x + x&y + x&z), d, contrasts=cs)
 mm = ModelMatrix(mf)
 @test mm.m == [1 0 -1  0 -1  0
                0 1  0 -1  0 -1
@@ -532,17 +532,17 @@ mm = ModelMatrix(mf)
 
 # Ensure that random effects terms are dropped from coefnames
 df = DataFrame(x = [1,2,3], y = [4,5,6])
-mf = ModelFrame(y ~ 1 + (1 | x), df)
+mf = ModelFrame(@formula(y ~ 1 + (1 | x)), df)
 @test coefnames(mf) == ["(Intercept)"]
 
-mf = ModelFrame(y ~ 0 + (1 | x), df)
+mf = ModelFrame(@formula(y ~ 0 + (1 | x)), df)
 @test_throws ErrorException ModelMatrix(mf)
 @test coefnames(mf) == Vector{Compat.UTF8String}()
 
 
 # Ensure X is not a view on df column
 df = DataFrame(x = [1.0,2.0,3.0], y = [4.0,5.0,6.0])
-mf = ModelFrame(y ~ 0 + x, df)
+mf = ModelFrame(@formula(y ~ 0 + x), df)
 X = ModelMatrix(mf).m
 X[1] = 0.0
 @test mf.df[1, :x] == 1.0

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -31,7 +31,7 @@ d[:x2] = [9:12;]
 d[:x3] = [13:16;]
 d[:x4] = [17:20;]
 
-f = y ~ x1 * x2
+f = @formula(y ~ x1 * x2)
 m = fit(DummyMod, f, d)
 @test model_response(m) == d[:y]
 
@@ -62,7 +62,7 @@ show(io, m)
 
 ## with categorical variables
 d[:x1p] = PooledDataArray(d[:x1])
-f2 = y ~ x1p
+f2 = @formula(y ~ x1p)
 m2 = fit(DummyMod, f2, d)
 
 @test coeftable(m2).rownms == ["(Intercept)", "x1p: 6", "x1p: 7", "x1p: 8"]
@@ -78,7 +78,7 @@ d3[:x1p] = PooledDataArray(d3[:x1])
 
 ## fit with contrasts specified
 d[:x2p] = PooledDataArray(d[:x2])
-f3 = y ~ x1p + x2p
+f3 = @formula(y ~ x1p + x2p)
 m3 = fit(DummyMod, f3, d)
 fit(DummyMod, f3, d, contrasts = Dict(:x1p => EffectsCoding()))
 fit(DummyMod, f3, d, contrasts = Dict(:x1p => EffectsCoding(),


### PR DESCRIPTION
This copies over the definition of `@formula` from StatsModels and deprecates `@~` for Julia versions where `~` parses as an infix macro rather than a regular call.