### PR TITLE
Suppress deprecation warning in v0.6

### DIFF
--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -419,7 +419,7 @@ function droprandomeffects(trms::Terms)
     else
         # the rows of `trms.factors` correspond to `eterms`, the columns to `terms`
         # After dropping random-effects terms we drop any eterms whose rows are all false
-        ckeep = !retrms                 # columns to retain
+        ckeep = map(!, retrms)                 # columns to retain
         facs = trms.factors[:, ckeep]
         rkeep = vec(sum(facs, 2) .> 0)
         Terms(trms.terms[ckeep], trms.eterms[rkeep], facs[rkeep, :],


### PR DESCRIPTION
julia v0.6 deprecates `!retrms` in favor of `.!retrms` but that syntax is not available in v0.5 or through the `Compat` package