### PR TITLE
Fix handling of non-Int row indices

### DIFF
--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -62,16 +62,13 @@ immutable SubDataFrame{T <: AbstractVector{Int}} <: AbstractDataFrame
     end
 end
 
-function SubDataFrame{T <: AbstractVector{Int}}(parent::DataFrame, rows::T)
-    return SubDataFrame{T}(parent, rows)
+function SubDataFrame{T <: Integer}(parent::DataFrame, rows::AbstractVector{T})
+    rows = convert(Vector{Int}, rows)
+    return SubDataFrame{typeof(rows)}(parent, rows)
 end
 
 function SubDataFrame(parent::DataFrame, row::Integer)
     return SubDataFrame(parent, [row])
-end
-
-function SubDataFrame{S <: Integer}(parent::DataFrame, rows::AbstractVector{S})
-    return view(parent, Int(rows))
 end
 
 

--- a/test/data.jl
+++ b/test/data.jl
@@ -66,6 +66,10 @@ module TestData
     @test size(sdf6a) == (1,3)
     sdf6d = view(df6, [1,3], :B)
     @test size(sdf6d) == (2,1)
+    sdf6e = view(df6, 0x01)
+    @test size(sdf6e) == (1,3)
+    sdf6f = view(df6, UInt64[1, 2])
+    @test size(sdf6f) == (2,3)
 
     #test_group("ref")
     @test sdf6a[1,2] == 4


### PR DESCRIPTION
Non-`Int64` row-indices were not being correctly converted to `Int64`.

- explicit conversion to `Vector{Int64}`
- test-cases added

Interestingly, this came up only when DataFrames was precompiled into a userimg (see JuliaLang/julia#21164) and only after the rename of `sub()` to `view()`