### PR TITLE
Fix isna, allna and anyna deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 
 language: julia
 julia:
-  - 0.5
+  - 0.6
   - nightly
 os:
   - linux

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 DataFrames.jl
 =============
 
-[![0.4](http://pkg.julialang.org/badges/DataFrames_0.4.svg)](http://pkg.julialang.org/?pkg=DataFrames)
-[![0.5](http://pkg.julialang.org/badges/DataFrames_0.5.svg)](http://pkg.julialang.org/?pkg=DataFrames)
 [![0.6](http://pkg.julialang.org/badges/DataFrames_0.6.svg)](http://pkg.julialang.org/?pkg=DataFrames)
+[![0.7](http://pkg.julialang.org/badges/DataFrames_0.7.svg)](http://pkg.julialang.org/?pkg=DataFrames)
 
 [![Coverage Status](https://coveralls.io/repos/JuliaStats/DataFrames.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaStats/DataFrames.jl?branch=master)
 [![Travis Build Status](https://travis-ci.org/JuliaStats/DataFrames.jl.svg?branch=master)](https://travis-ci.org/JuliaStats/DataFrames.jl)

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6-
 DataArrays 0.3.4
 StatsBase 0.11.0
 GZip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -78,7 +78,7 @@ module TestCat
     dfr = vcat(df2, df3)
     @test size(dfr) == (8,2)
     @test names(df2) == names(dfr)
-    @test isna(dfr[8,:x2])
+    @test isna.(dfr[8,:x2])
 
     # Eltype promotion
     @test eltypes(vcat(DataFrame(a = [1]), DataFrame(a = [2.1]))) == [Float64]

--- a/test/data.jl
+++ b/test/data.jl
@@ -32,7 +32,7 @@ module TestData
 
     #test_group("ref")
     @test df6[2, 3] == "two"
-    @test isna(df6[3, 3])
+    @test isna.(df6[3, 3])
     @test df6[2, :C] == "two"
     @test isequal(df6[:B], dvint)
     @test size(df6[[2,3]], 2) == 2
@@ -278,9 +278,9 @@ module TestData
 
     #test_group("New DataVector constructors")
     dv = DataArray(Int, 5)
-    @test all(isna(dv))
+    @test all(isna, dv)
     dv = DataArray(Float64, 5)
-    @test all(isna(dv))
+    @test all(isna, dv)
     dv = @data(zeros(5))
     @test all(dv .== 0.0)
     dv = @data(ones(5))
@@ -288,7 +288,7 @@ module TestData
 
     # No more NA corruption
     dv = @data(ones(10_000))
-    @test !any(isna(dv))
+    @test !any(isna, dv)
 
     PooledDataArray(falses(2), falses(2))
     PooledDataArray(falses(2), trues(2))

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -111,9 +111,9 @@ module TestDataFrame
     @test typeof(df[:, 1]) == DataVector{Int}
     @test typeof(df[:, 2]) == DataVector{Int}
     @test typeof(df[:, 3]) == DataVector{Int}
-    @test allna(df[:, 1])
-    @test allna(df[:, 2])
-    @test allna(df[:, 3])
+    @test all(isna, df[:, 1])
+    @test all(isna, df[:, 2])
+    @test all(isna, df[:, 3])
 
     df = DataFrame(Any[Int, Float64, String], 100)
     @test size(df, 1) == 100
@@ -121,9 +121,9 @@ module TestDataFrame
     @test typeof(df[:, 1]) == DataVector{Int}
     @test typeof(df[:, 2]) == DataVector{Float64}
     @test typeof(df[:, 3]) == DataVector{String}
-    @test allna(df[:, 1])
-    @test allna(df[:, 2])
-    @test allna(df[:, 3])
+    @test all(isna, df[:, 1])
+    @test all(isna, df[:, 2])
+    @test all(isna, df[:, 3])
 
     df = DataFrame(Any[Int, Float64, String], [:A, :B, :C], 100)
     @test size(df, 1) == 100
@@ -131,9 +131,9 @@ module TestDataFrame
     @test typeof(df[:, 1]) == DataVector{Int}
     @test typeof(df[:, 2]) == DataVector{Float64}
     @test typeof(df[:, 3]) == DataVector{String}
-    @test allna(df[:, 1])
-    @test allna(df[:, 2])
-    @test allna(df[:, 3])
+    @test all(isna, df[:, 1])
+    @test all(isna, df[:, 2])
+    @test all(isna, df[:, 3])
 
 
     df = DataFrame(DataType[Int, Float64, Compat.UTF8String],[:A, :B, :C], [false,false,true],100)
@@ -142,9 +142,9 @@ module TestDataFrame
     @test typeof(df[:, 1]) == DataVector{Int}
     @test typeof(df[:, 2]) == DataVector{Float64}
     @test typeof(df[:, 3]) == PooledDataVector{Compat.UTF8String,UInt32}
-    @test allna(df[:, 1])
-    @test allna(df[:, 2])
-    @test allna(df[:, 3])
+    @test all(isna, df[:, 1])
+    @test all(isna, df[:, 2])
+    @test all(isna, df[:, 3])
 
 
     df = convert(DataFrame, zeros(10, 5))

--- a/test/join.jl
+++ b/test/join.jl
@@ -18,11 +18,11 @@ module TestJoin
                       Job = @data(["Lawyer", "Doctor", "Florist", NA, "Farmer"]))
 
     # (Tests use current column ordering but don't promote it)
-    right = outer[(!).(isna(outer[:Job])), [:Name, :ID, :Job]]
-    left = outer[(!).(isna(outer[:Name])), :]
-    inner = left[(!).(isna(left[:Job])), :]
+    right = outer[(!).(isna.(outer[:Job])), [:Name, :ID, :Job]]
+    left = outer[(!).(isna.(outer[:Name])), :]
+    inner = left[(!).(isna.(left[:Job])), :]
     semi = unique(inner[:, [:ID, :Name]])
-    anti = left[isna(left[:Job]), [:ID, :Name]]
+    anti = left[isna.(left[:Job]), [:ID, :Name]]
 
     @test isequal(join(name, job, on = :ID), inner)
     @test isequal(join(name, job, on = :ID, kind = :inner), inner)


### PR DESCRIPTION
Also fix some uses of all(isna(x)) and any(isna(x)), and avoid computing
the number of missing values twice in describe().

@ararslan I'm not sure whether I should bump the dependency on DataArrays. AFAICT this form worked before the deprecation was added, since it's possible since Julia 0.5, right?