### PR TITLE
Restore an orphan commit from the v0.4.3 tag

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
-julia 0.2-
+julia 0.2- 0.3-
 DataArrays
-Stats
+StatsBase 0.3.8-
 GZip
 Blocks
 SortingAlgorithms

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -2,7 +2,7 @@
 # strictly required: one pulls the names into DataFrames
 # for easy access within the module, whereas the other call
 # pushes those names into Main.
-using Stats
+using StatsBase
 using DataArrays
 
 module DataFrames
@@ -16,7 +16,7 @@ module DataFrames
 using Base.Intrinsics
 using DataArrays
 using GZip
-using Stats
+using StatsBase
 using SortingAlgorithms
 
 ##############################################################################
@@ -34,7 +34,7 @@ const DEFAULT_COLUMN_TYPE = Float64
 ##############################################################################
 
 importall Base
-importall Stats
+importall StatsBase
 import Base.Sort
 import Base.Sort.Algorithm, Base.Sort.By, Base.Sort.Forward
 import Base.Sort.Ordering, Base.Sort.Perm, Base.Sort.lt

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -68,7 +68,7 @@ let
 
     ffts = [fft]
 
-    binary_vector_operators = [dot, cor, cov, cor_spearman]
+    binary_vector_operators = [dot, cor, cov, corspearman]
 
     columnar_operators = [colmins, colmaxs, colprods, colsums,
                           colmeans, colmedians, colstds, colvars,


### PR DESCRIPTION
Doing some scraping of metadata, found that the v0.4.3 tag of DataFrames is the below orphaned commit, it's not in the history of any branches and wasn't pushed as a git tag. I don't actually want anyone to merge this, but just so this commit can be checked out without getting a "fatal: reference is not a tree" error, it would be good if someone with commit access could do
```
git remote add tkelman https://github.com/tkelman/DataFrames.jl
git fetch tkelman
git checkout 84523937447b336dfcbf1747b123e9d1da1308c6
git tag v0.4.3
git push origin v0.4.3
```

That is all, if someone does that, we can go ahead and close this. Thanks!