### PR TITLE
make column Vector always of type Any so arbitrary vectors always can be pushed to it

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -70,7 +70,7 @@ size(df1)
 
 """
 type DataFrame <: AbstractDataFrame
-    columns::Vector
+    columns::Vector{Any}
     colindex::Index
 
     function DataFrame(columns::Vector, colindex::Index)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -317,4 +317,9 @@ module TestDataFrame
     df4[2,:Mass] = NA
     @test isequal(df2, df4)
 
+
+    let d = DataFrames.DataFrame([["hello", "world"]], [:strs])
+        d[:num] = [1,2]
+        @test d[:num] == [1,2]
+    end
 end


### PR DESCRIPTION
Ref https://discourse.julialang.org/t/add-a-column-of-ints-to-a-dataframe-of-strings/4976

Not sure about performance implications.