### PR TITLE
Fixed Compat UTF8String deprecation warnings.

### DIFF
--- a/src/dataframe/io.jl
+++ b/src/dataframe/io.jl
@@ -621,7 +621,7 @@ function builddf(rows::Integer,
                     continue
                 else
                     is_bool = false
-                    values = Vector{Compat.UTF8String}(rows)
+                    values = Vector{String}(rows)
                     i = 0
                     continue
                 end
@@ -629,7 +629,7 @@ function builddf(rows::Integer,
 
             # (4) Fallback to String
             values[i], wasparsed, missing[i] =
-              bytestotype(Compat.UTF8String,
+              bytestotype(String,
                           p.bytes,
                           left,
                           right,
@@ -827,8 +827,8 @@ function readtable(io::IO,
 
     if !isempty(eltypes)
         for j in 1:length(eltypes)
-            if !(eltypes[j] in [Compat.UTF8String, Bool, Float64, Int64])
-                throw(ArgumentError("Invalid eltype $(eltypes[j]) encountered.\nValid eltypes: $(Compat.UTF8String), Bool, Float64 or Int64"))
+            if !(eltypes[j] in [String, Bool, Float64, Int64])
+                throw(ArgumentError("Invalid eltype $(eltypes[j]) encountered.\nValid eltypes: $(String), Bool, Float64 or Int64"))
             end
         end
     end
@@ -1175,7 +1175,7 @@ function filldf!(df::DataFrame,
 
             # NB: Assumes perfect type stability
             # Use subtypes here
-            if !(T in [Int, Float64, Bool, Compat.UTF8String])
+            if !(T in [Int, Float64, Bool, String])
                 error("Invalid eltype encountered")
             end
             c.data[i], wasparsed, c.na[i] =

--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -565,11 +565,11 @@ function coefnames(mf::ModelFrame)
     terms = droprandomeffects(dropresponse!(mf.terms))
 
     ## strategy mirrors ModelMatrx constructor:
-    eterm_names = Dict{Tuple{Symbol,Bool}, Vector{Compat.UTF8String}}()
-    term_names = Vector{Compat.UTF8String}[]
+    eterm_names = Dict{Tuple{Symbol,Bool}, Vector{String}}()
+    term_names = Vector{String}[]
 
     if terms.intercept
-        push!(term_names, Compat.UTF8String["(Intercept)"])
+        push!(term_names, String["(Intercept)"])
     end
 
     factors = terms.factors
@@ -577,7 +577,7 @@ function coefnames(mf::ModelFrame)
     for (i_term, term) in enumerate(terms.terms)
 
         ## names for columns for eval terms
-        names = Vector{Compat.UTF8String}[]
+        names = Vector{String}[]
 
         ff = Compat.view(factors, :, i_term)
         eterms = Compat.view(terms.eterms, ff)
@@ -592,7 +592,7 @@ function coefnames(mf::ModelFrame)
         push!(term_names, expandtermnames(names))
     end
 
-    reduce(vcat, Vector{Compat.UTF8String}(), term_names)
+    reduce(vcat, Vector{String}(), term_names)
 end
 
 function Formula(t::Terms)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -136,12 +136,12 @@ module TestDataFrame
     @test all(isna, df[:, 3])
 
 
-    df = DataFrame(DataType[Int, Float64, Compat.UTF8String],[:A, :B, :C], [false,false,true],100)
+    df = DataFrame(DataType[Int, Float64, String],[:A, :B, :C], [false,false,true],100)
     @test size(df, 1) == 100
     @test size(df, 2) == 3
     @test typeof(df[:, 1]) == DataVector{Int}
     @test typeof(df[:, 2]) == DataVector{Float64}
-    @test typeof(df[:, 3]) == PooledDataVector{Compat.UTF8String,UInt32}
+    @test typeof(df[:, 3]) == PooledDataVector{String,UInt32}
     @test all(isna, df[:, 1])
     @test all(isna, df[:, 2])
     @test all(isna, df[:, 3])

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -537,7 +537,7 @@ mf = ModelFrame(@formula(y ~ 1 + (1 | x)), df)
 
 mf = ModelFrame(@formula(y ~ 0 + (1 | x)), df)
 @test_throws ErrorException ModelMatrix(mf)
-@test coefnames(mf) == Vector{Compat.UTF8String}()
+@test coefnames(mf) == Vector{String}()
 
 
 # Ensure X is not a view on df column

--- a/test/io.jl
+++ b/test/io.jl
@@ -228,7 +228,7 @@ module TestIO
     filename = "$data/factors/mixedvartypes.csv"
     df = readtable(filename, makefactors = true)
 
-    @test typeof(df[:factorvar]) == PooledDataArray{Compat.UTF8String,UInt32,1}
+    @test typeof(df[:factorvar]) == PooledDataArray{String,UInt32,1}
     @test typeof(df[:floatvar]) == DataArray{Float64,1}
 
     # Readtable shouldn't silently drop data when reading highly compressed gz.
@@ -238,7 +238,7 @@ module TestIO
     # Readtable type inference
     filename = "$data/typeinference/bool.csv"
     df = readtable(filename)
-    @test typeof(df[:Name]) == DataArray{Compat.UTF8String,1}
+    @test typeof(df[:Name]) == DataArray{String,1}
     @test typeof(df[:IsMale]) == DataArray{Bool,1}
     @test df[:IsMale][1] == true
     @test df[:IsMale][4] == false
@@ -249,11 +249,11 @@ module TestIO
     @test typeof(df[:IntlikeColumn]) == DataArray{Float64,1}
     @test typeof(df[:FloatColumn]) == DataArray{Float64,1}
     @test typeof(df[:BoolColumn]) == DataArray{Bool,1}
-    @test typeof(df[:StringColumn]) == DataArray{Compat.UTF8String,1}
+    @test typeof(df[:StringColumn]) == DataArray{String,1}
 
     filename = "$data/typeinference/mixedtypes.csv"
     df = readtable(filename)
-    @test typeof(df[:c1]) == DataArray{Compat.UTF8String,1}
+    @test typeof(df[:c1]) == DataArray{String,1}
     @test df[:c1][1] == "1"
     @test df[:c1][2] == "2.0"
     @test df[:c1][3] == "true"
@@ -261,7 +261,7 @@ module TestIO
     @test df[:c2][1] == 1.0
     @test df[:c2][2] == 3.0
     @test df[:c2][3] == 4.5
-    @test typeof(df[:c3]) == DataArray{Compat.UTF8String,1}
+    @test typeof(df[:c3]) == DataArray{String,1}
     @test df[:c3][1] == "0"
     @test df[:c3][2] == "1"
     @test df[:c3][3] == "f"
@@ -269,7 +269,7 @@ module TestIO
     @test df[:c4][1] == true
     @test df[:c4][2] == false
     @test df[:c4][3] == true
-    @test typeof(df[:c5]) == DataArray{Compat.UTF8String,1}
+    @test typeof(df[:c5]) == DataArray{String,1}
     @test df[:c5][1] == "False"
     @test df[:c5][2] == "true"
     @test df[:c5][3] == "true"
@@ -280,17 +280,17 @@ module TestIO
     df = readtable(filename)
     @test typeof(df[:n]) == DataArray{Int,1}
     @test df[:n][1] == 1
-    @test typeof(df[:s]) == DataArray{Compat.UTF8String,1}
+    @test typeof(df[:s]) == DataArray{String,1}
     @test df[:s][1] == "text"
     @test typeof(df[:f]) == DataArray{Float64,1}
     @test df[:f][1] == 2.3
     @test typeof(df[:b]) == DataArray{Bool,1}
     @test df[:b][1] == true
 
-    df = readtable(filename, eltypes = [Int64, Compat.UTF8String, Float64, Bool])
+    df = readtable(filename, eltypes = [Int64, String, Float64, Bool])
     @test typeof(df[:n]) == DataArray{Int64,1}
     @test df[:n][1] == 1
-    @test typeof(df[:s]) == DataArray{Compat.UTF8String,1}
+    @test typeof(df[:s]) == DataArray{String,1}
     @test df[:s][1] == "text"
     @test df[:s][4] == "text ole"
     @test typeof(df[:f]) == DataArray{Float64,1}
@@ -299,7 +299,7 @@ module TestIO
     @test df[:b][1] == true
     @test df[:b][2] == false
 
-    df = readtable(filename, eltypes = [Int64, Compat.UTF8String, Float64, Compat.UTF8String])
+    df = readtable(filename, eltypes = [Int64, String, Float64, String])
     @test typeof(df[:n]) == DataArray{Int64,1}
     @test df[:n][1] == 1.0
     @test isna(df[:s][3])
@@ -308,7 +308,7 @@ module TestIO
     @test df[:f][1] == 2.3
     @test df[:f][2] == 0.2
     @test df[:f][3] == 5.7
-    @test typeof(df[:b]) == DataArray{Compat.UTF8String,1}
+    @test typeof(df[:b]) == DataArray{String,1}
     @test df[:b][1] == "T"
     @test df[:b][2] == "FALSE"
 

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -89,7 +89,7 @@ fit(DummyMod, f3, d, contrasts = Dict(:x1p => EffectsCoding(),
 
 ## Another dummy model type to test fall-through show method
 immutable DummyModTwo <: RegressionModel
-    msg::Compat.UTF8String
+    msg::String
 end
 
 StatsBase.fit(::Type{DummyModTwo}, ::Matrix, ::Vector) = DummyModTwo("hello!")


### PR DESCRIPTION
Closes #1202.

Replaced all instances of Compat.UTF8String with String.
NOTE: Compat deprecated UTF8String when it dropped julia-0.4 support.