### PR TITLE
Pair Constructor

### DIFF
--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -104,10 +104,11 @@ julia> nulls(Int, 1, 3)
 
 ## The `DataFrame` Type
 
-The `DataFrame` type can be used to represent data tables, each column of which is a vector. You can specify the columns using keyword arguments:
+The `DataFrame` type can be used to represent data tables, each column of which is a vector. You can specify the columns using keyword arguments or pairs:
 
 ```julia
 df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"])
+df = DataFrame(:A => 1:4, :B => ["M", "F", "F", "M"])
 ```
 
 It is also possible to construct a `DataFrame` in stages:

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -9,6 +9,7 @@ particularly a Vector or CategoricalVector.
 ```julia
 DataFrame(columns::Vector, names::Vector{Symbol})
 DataFrame(kwargs...)
+DataFrame(pairs::Pair{Symbol}...)
 DataFrame() # an empty DataFrame
 DataFrame(t::Type, nrows::Integer, ncols::Integer) # an empty DataFrame of arbitrary size
 DataFrame(column_eltypes::Vector, names::Vector, nrows::Integer)
@@ -105,10 +106,18 @@ type DataFrame <: AbstractDataFrame
     end
 end
 
-function DataFrame(; kwargs...)
-    colnames = Symbol[k for (k,v) in kwargs]
-    columns = Any[v for (k,v) in kwargs]
+function DataFrame(pairs::Pair{Symbol,<:Any}...)
+    colnames = Symbol[k for (k,v) in pairs]
+    columns = Any[v for (k,v) in pairs]
     DataFrame(columns, Index(colnames))
+end
+
+function DataFrame(; kwargs...)
+    if isempty(kwargs)
+        DataFrame(Any[], Index())
+    else
+        DataFrame((k => v for (k,v) in kwargs)...)
+    end
 end
 
 function DataFrame(columns::AbstractVector,

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -52,6 +52,16 @@ module TestConstructors
 
     @test DataFrame(a=1, b=1:2) == DataFrame(a=[1,1], b=[1,2])
 
+    @testset "pair constructor" begin
+        df = DataFrame(:x1 => zeros(3), :x2 => ones(3))
+        @test size(df, 1) == 3
+        @test size(df, 2) == 2
+        @test isequal(df, DataFrame(x1 = [0.0, 0.0, 0.0], x2 = [1.0, 1.0, 1.0]))
+
+        df = DataFrame(:type => [], :begin => [])
+        @test names(df) == [:type, :begin]
+    end
+
     @testset "associative" begin
         df = DataFrame(Dict(:A => 1:3, :B => 4:6))
         @test df == DataFrame(A = 1:3, B = 4:6)


### PR DESCRIPTION
Created a `DataFrame` constructor that uses pairs. Works similarly to the keyword argument constructor but allows you to use column names that are Julia keywords:

```julia
julia> DataFrame(type=[])
ERROR: syntax: unexpected "="

julia> DataFrame(:type => [])
0×1 DataFrames.DataFrame
```