### PR TITLE
Remove use of end in a cat expression

### DIFF
--- a/src/statsmodels/contrasts.jl
+++ b/src/statsmodels/contrasts.jl
@@ -289,7 +289,7 @@ function contrasts_matrix(C::HelmertCoding, baseind, n)
     end
 
     # re-shuffle the rows such that base is the all -1.0 row (currently first)
-    mat = mat[[baseind; 1:(baseind-1); (baseind+1):end], :]
+    mat = mat[[baseind; 1:(baseind-1); (baseind+1):n], :]
     return mat
 end
 


### PR DESCRIPTION
Fixes #1206. The parsing of `end` in `cat` expressions changed recently, which broke our use of `end` here.